### PR TITLE
Add Exercise 9 -- Opaque Type Aliases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ lazy val `scala-2-to-scala-3-master` = (project in file("."))
     `exercise_005_using_and_summon`,
     `exercise_006_givens`,
     `exercise_007_enum_and_export`,
-    `exercise_008_union_types`
+    `exercise_008_union_types`,
+    `exercise_009_opaque_type_aliases`
  )
   .settings(scalaVersion := dottyVersion)
  .settings(CommonSettings.commonSettings: _*)
@@ -60,4 +61,8 @@ lazy val `exercise_008_union_types` = project
   .settings(scalaVersion := dottyVersion)
   .configure(CommonSettings.configure)
   .dependsOn(common % "test->test;compile->compile")
-       
+
+lazy val `exercise_009_opaque_type_aliases` = project
+  .settings(scalaVersion := dottyVersion)
+  .configure(CommonSettings.configure)
+  .dependsOn(common % "test->test;compile->compile")

--- a/exercise_009_opaque_type_aliases/README.md
+++ b/exercise_009_opaque_type_aliases/README.md
@@ -1,0 +1,62 @@
+# Union Types
+
+## Background
+
+In the previous exercise, we re-encoded the protocol of the different actors
+in our application from a `sealed trait` based one to one using Dotty
+enumerations. This however, is only a small first step towards a major
+simplification of the way encode the exchange of messages between actors.
+We will now explore using Dotty's `Union Types` to vastly simplify the Scala 2
+based implementation. We will succeed in eliminating the so-called message
+adapters and response wrappers from our code!
+
+The general idea is that we have both an external protocol for an actor (which
+is exactly the same as in the original implementation) and an [extended] 
+internal protocol that also 'understands' the responses the actor can receive.
+
+## Steps
+
+Have close look at the 4 different actors in the application:
+
+  - `SudokuProblemSender`
+  - `SudokuSolver`
+  - `SudokuProgressTracker`
+  - `SudokuDetailProcessor`
+
+Which of these actors receive messages that are responses from other actors?
+
+
+`Hint:` In its present form, the application utilises message adapters. You
+      can easily spot these by doing a search on the factory method to
+      create them: `context.messageAdapter`.
+
+`Tip:`  Tackle the `SudokuProblemSender` first. After this, proceed with
+      the other actors.
+
+- Create a type alias named `CommandAndResponses` for the Union of the
+  actor's external protocol (`Command`) and the `Response` message types.
+  This new type will be the type of the internal protocol.
+
+- Adapt the `apply` method that creates the actor's behaviour so that it
+  still is the original behaviour as seen from the outside, but which
+  has the extended behaviour (corresponding to `CommandAndResponses`).
+  You will need to make a few extra modifications to make everything
+  type check. Some hints that may put you on the right track:
+
+  - Note that `Behaviors.setup` has a type parameter
+  - `Behaviors.setup` returns a `Behavior` of some type. Look at the
+    API docs of `Behavior` and specifically at the `narrow` method.
+    You will need to apply this method in your code
+  - A typical pattern in Akka Typed code is the inclusion of a so-called
+    `ActorRef` conventionally called `replyTo`. In the existing code,
+    this is the message adaptor. With the latter being eliminated from
+    the code, you need to substitute it with another `ActorRef`. Which
+    one makes sense? In this context, have a look at the available
+    members on an actor's `context`
+
+- Eliminate any unused code such as:
+  - The message adapters
+  - The `Response` message wrappers
+
+- Verify that the application continues to work correctly 
+  

--- a/exercise_009_opaque_type_aliases/src/main/resources/application.conf
+++ b/exercise_009_opaque_type_aliases/src/main/resources/application.conf
@@ -1,0 +1,24 @@
+akka {
+
+  log-dead-letters = on
+  logger-startup-timeout = 30s
+
+  actor {
+    provider = local
+
+    debug {
+      lifecycle = on
+      unhandled = on
+    }
+  }
+
+  remote {
+
+    artery {
+      canonical {
+        hostname = "127.0.0.1"
+        port = 2550
+      }
+    }
+  }
+}

--- a/exercise_009_opaque_type_aliases/src/main/resources/logback.xml
+++ b/exercise_009_opaque_type_aliases/src/main/resources/logback.xml
@@ -1,0 +1,24 @@
+<configuration>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>info</level>
+        </filter>
+        <encoder>
+            <pattern>%date{HH:mm:ss} %-5level [%X{akkaSource}] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka.cluster.pi" level="info" additivity="false">
+        <appender-ref ref="console"/>
+    </logger>
+
+    <logger name="akka.actor.RepointableActorRef" level="info" additivity="false">
+        <appender-ref ref="console"/>
+    </logger>
+
+    <root level="info">
+        <appender-ref ref="console"/>
+    </root>
+
+</configuration>

--- a/exercise_009_opaque_type_aliases/src/main/resources/sudokusolver.conf
+++ b/exercise_009_opaque_type_aliases/src/main/resources/sudokusolver.conf
@@ -1,0 +1,7 @@
+sudoku-solver {
+  solver-stash-buffer-size = 50
+
+  problem-sender {
+    send-interval = 400 millis
+  }
+}

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -1,0 +1,56 @@
+/**
+  * Copyright © 2016-2020 Lightbend, Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *
+  * NO COMMERCIAL SUPPORT OR ANY OTHER FORM OF SUPPORT IS OFFERED ON
+  * THIS SOFTWARE BY LIGHTBEND, Inc.
+  *
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package org.lunatechlabs.dotty
+
+import akka.NotUsed
+import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
+import akka.actor.typed.scaladsl.{Behaviors, Routers}
+import akka.actor.typed.{ActorSystem, Behavior, Terminated}
+import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import scala.io.StdIn
+import Console.{GREEN, RESET}
+
+object Main {
+  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
+    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+    // Start a SodukuSolver
+    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+    // Start a Sudoku problem sender
+    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+
+    Behaviors.receiveSignal {
+      case (_, Terminated(_)) =>
+        Behaviors.stopped
+    }
+  }
+}
+
+object SudokuSolverMain {
+
+  def main(args: Array[String]): Unit = {
+
+    val system = ActorSystem[NotUsed](Main(), "sudoku-solver-system")
+
+    println(s"${GREEN}Hit RETURN to stop solver${RESET}")
+    StdIn.readLine()
+    system.terminate()
+  }
+}

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -1,0 +1,22 @@
+package org.lunatechlabs.dotty.sudoku
+
+object CellMappings {
+
+  def rowToColumnCoordinates(rowNr: Int, cellNr: Int): (Int, Int) =
+    (cellNr, rowNr)
+
+  def rowToBlockCoordinates(rowNr: Int, cellNr: Int): (Int, Int) =
+    ((rowNr / 3) * 3 + cellNr / 3, (rowNr % 3) * 3 + cellNr % 3)
+
+  def columnToRowCoordinates(columnNr: Int, cellNr: Int): (Int, Int) =
+    (cellNr, columnNr)
+
+  def columnToBlockCoordinates(columnNr: Int, cellNr: Int): (Int, Int) =
+    rowToBlockCoordinates(cellNr, columnNr)
+
+  def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
+    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+
+  def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
+    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+}

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -1,0 +1,45 @@
+package org.lunatechlabs.dotty.sudoku
+
+// Extension instance wraps extension methods for type ReductionSet
+extension reductionRules on (reductionSet: ReductionSet) {
+
+  def applyReductionRuleOne: ReductionSet = {
+    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
+    val completeInputCellGroups = inputCellsGrouped filter { (set, setOccurrences) =>
+      set.size == setOccurrences.length
+    }
+    val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
+    (completeAndIsolatedValueSets foldLeft reductionSet) { (cells, caivSet) =>
+      cells map {
+        cell => if (cell != caivSet) cell &~ caivSet else cell
+      }
+    }
+  }
+
+  def applyReductionRuleTwo: ReductionSet = {
+    val valueOccurrences = CELLPossibleValues map { value =>
+      (cellIndexesVector zip reductionSet foldLeft Vector.empty[Int]) {
+        case (acc, (index, cell)) =>
+          if (cell contains value) index +: acc else acc
+      }
+    }
+
+    val cellIndexesToValues =
+      (CELLPossibleValues zip valueOccurrences)
+        .groupBy ((value, occurrence) => occurrence)
+        .filter  ((loc, occ) => loc.length == occ.length && loc.length <= 6 )
+
+    val cellIndexListToReducedValue = cellIndexesToValues map { (index, seq) =>
+      (index, (seq map ((value, _) => value )).toSet)
+    }
+
+    val cellIndexToReducedValue = cellIndexListToReducedValue flatMap { (cellIndexList, reducedValue) => 
+      cellIndexList map { cellIndex => cellIndex -> reducedValue }
+    }
+
+    (reductionSet.zipWithIndex foldRight Vector.empty[CellContent]) {
+      case ((cellValue, cellIndex), acc) =>
+        cellIndexToReducedValue.getOrElse(cellIndex, cellValue) +: acc
+    }
+  }
+}

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -1,0 +1,124 @@
+package org.lunatechlabs.dotty.sudoku
+
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+import akka.actor.typed.{ActorRef, Behavior}
+import org.lunatechlabs.dotty.sudoku.SudokuDetailProcessor.UpdateSender
+
+object SudokuDetailProcessor {
+
+  // My protocol
+  enum Command {
+    case ResetSudokuDetailState
+    case Update(cellUpdates: CellUpdates, replyTo: ActorRef[Response])
+    case GetSudokuDetailState(replyTo: ActorRef[SudokuProgressTracker.Command])
+  }
+  export Command._
+
+  // My responses
+  enum Response {
+    case RowUpdate(id: Int, cellUpdates: CellUpdates)
+    case ColumnUpdate(id: Int, cellUpdates: CellUpdates)
+    case BlockUpdate(id: Int, cellUpdates: CellUpdates)
+    case SudokuDetailUnchanged
+  }
+  export Response._
+
+  val InitialDetailState: ReductionSet = cellIndexesVector.map(_ => initialCell)
+
+  def apply[DetailType <: SudokoDetailType](id: Int,
+                                            state: ReductionSet = InitialDetailState)
+                                           (using updateSender: UpdateSender[DetailType]): Behavior[Command] = {
+    Behaviors.setup { context =>
+      (new SudokuDetailProcessor[DetailType](context)).operational(id, state, fullyReduced = false)
+    }
+  }
+
+  trait UpdateSender[A] {
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit
+
+    def processorName(id: Int): String
+  }
+
+  given UpdateSender[Row] = new UpdateSender[Row] {
+    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit = {
+      sender ! RowUpdate(id, cellUpdates)
+    }
+    override def processorName(id: Int): String = s"row-processor-$id"
+  }
+
+  given UpdateSender[Column] = new UpdateSender[Column] {
+    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
+      sender ! ColumnUpdate(id, cellUpdates)
+    override def processorName(id: Int): String = s"col-processor-$id"
+  }
+
+  given UpdateSender[Block] = new UpdateSender[Block] {
+    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
+      sender ! BlockUpdate(id, cellUpdates)
+    override def processorName(id: Int): String = s"blk-processor-$id"
+  }
+}
+
+class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] private (context: ActorContext[SudokuDetailProcessor.Command]) {
+
+  import SudokuDetailProcessor._
+
+  def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
+    Behaviors.receiveMessagePartial {
+    case Update(cellUpdates, replyTo) if ! fullyReduced =>
+      val previousState = state
+      val updatedState = mergeState(state, cellUpdates)
+      if (updatedState == previousState && cellUpdates != cellUpdatesEmpty) {
+        replyTo ! SudokuDetailUnchanged
+        Behaviors.same
+      } else {
+        val transformedUpdatedState = updatedState.applyReductionRuleOne.applyReductionRuleTwo
+        if (transformedUpdatedState == state) {
+          replyTo ! SudokuDetailUnchanged
+          Behaviors.same
+        } else {
+          val updateSender = summon[UpdateSender[DetailType]]
+          // The following can also be written as:
+          // given ActorRef[Response] = replyTo
+          // updateSender.sendUpdate(id, stateChanges(state, transformedUpdatedState))         
+          updateSender.sendUpdate(id, stateChanges(state, transformedUpdatedState))(using replyTo)
+          operational(id, transformedUpdatedState, isFullyReduced(transformedUpdatedState))
+        }
+      }
+
+    case Update(cellUpdates, replyTo) =>
+      replyTo ! SudokuDetailUnchanged
+      Behaviors.same
+
+    case GetSudokuDetailState(replyTo) =>
+      replyTo ! SudokuProgressTracker.SudokuDetailState(id, state)
+      Behaviors.same
+
+    case ResetSudokuDetailState =>
+      operational(id, InitialDetailState, fullyReduced = false)
+
+  }
+
+  private def mergeState(state: ReductionSet, cellUpdates: CellUpdates): ReductionSet = {
+      (cellUpdates foldLeft state) {
+      case (stateTally, (index, updatedCellContent)) =>
+        stateTally.updated(index, stateTally(index) & updatedCellContent)
+    }
+  }
+
+  private def stateChanges(state: ReductionSet, updatedState: ReductionSet): CellUpdates = {
+    ((state zip updatedState).zipWithIndex foldRight cellUpdatesEmpty) {
+      case (((previousCellContent, updatedCellContent), index), cellUpdates)
+        if updatedCellContent != previousCellContent =>
+        (index, updatedCellContent) +: cellUpdates
+
+      case (_, cellUpdates) => cellUpdates
+    }
+  }
+
+  private def isFullyReduced(state: ReductionSet): Boolean = {
+    val allValuesInState = state.flatten
+    allValuesInState == allValuesInState.distinct
+  }
+
+}

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailType.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailType.scala
@@ -1,0 +1,6 @@
+package org.lunatechlabs.dotty.sudoku
+
+sealed trait SudokoDetailType
+case class Row(id: Int) extends SudokoDetailType
+case class Column(id: Int) extends SudokoDetailType
+case class Block(id: Int) extends SudokoDetailType

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuIO.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuIO.scala
@@ -1,0 +1,126 @@
+package org.lunatechlabs.dotty.sudoku
+
+import java.util.NoSuchElementException
+
+object SudokuIO {
+
+  def printRow( row: ReductionSet): String = {
+    def printSubRow( subRowNo: Int): String = {
+      val printItems = List(1,2,3) map( x => x + subRowNo * 3)
+      (for  (elem <- row) 
+        yield {
+          (printItems map (item => if ((elem & printItems.toSet).contains(item)) item.toString else " ")).mkString("")
+        }).mkString("| ", " | ", " |")
+    }
+    (for  (subRow <- 0 until 3)  yield printSubRow(subRow)).mkString("\n")
+  }
+
+  def printRowShort( row: ReductionSet): String = {
+    (for
+      (elem <- row)
+    yield {
+      if (elem.size == 1) elem.head.toString else " "
+    }).mkString("|","|","|")
+
+  }
+
+  private def sudokuCellRepresentation(content: CellContent): String = {
+    content.toList match {
+      case Nil => "x"
+      case singleValue +: Nil => singleValue.toString
+      case _ => " "
+    }
+  }
+
+  private def sudokuRowPrinter(threeRows: Vector[ReductionSet]): String = {
+    val rowSubBlocks = for {
+      row <- threeRows
+      rowSubBlock <- row.map(el => sudokuCellRepresentation(el)).sliding(3,3)
+      rPres = rowSubBlock.mkString
+
+    } yield rPres
+    rowSubBlocks.sliding(3,3).map(_.mkString("", "|", "")).mkString("|", "|\n|", "|\n")
+  }
+
+  def sudokuPrinter(result: SudokuSolver.SudokuSolution): String = {
+    result.sudoku
+      .sliding(3,3)
+      .map(sudokuRowPrinter)
+      .mkString("\n+---+---+---+\n", "+---+---+---+\n", "+---+---+---+")
+  }
+
+  /*
+   * FileLineTraversable code taken from "Scala in Depth" by Joshua Suereth
+   */
+
+  import java.io.{BufferedReader, File, FileReader}
+
+  class FileLineTraversable(file: File) extends Iterable[String] {
+    val fr = new FileReader(file)
+    val input = new BufferedReader(fr)
+    var cachedLine: Option[String] = None
+    var finished: Boolean = false
+
+    override def iterator: Iterator[String] = new Iterator[String] {
+
+      override def hasNext: Boolean = (cachedLine, finished) match {
+        case (Some(_), _) => true
+
+        case (None, true) => false
+
+        case (None, false) =>
+          try {
+            val line = input.readLine()
+            if (line == null) {
+              finished = true
+              input.close()
+              fr.close()
+              false
+            } else {
+              cachedLine = Some(line)
+              true
+            }
+          } catch {
+            case e: java.io.IOError =>
+              throw new IllegalStateException(e.toString)
+          }
+      }
+
+      override def next(): String = {
+        if (! hasNext) {
+          throw new NoSuchElementException("No more lines in file")
+        }
+        val currentLine = cachedLine.get
+        cachedLine = None
+        currentLine
+      }
+    }
+    override def toString: String =
+      "{Lines of " + file.getAbsolutePath + "}"
+  }
+
+  def convertFromCellsToComplete(cellsIn: Vector[(String, Int)]): Vector[(Int, CellUpdates)] =
+    for {
+      (rowCells, row) <- cellsIn
+      updates = (rowCells.zipWithIndex foldLeft cellUpdatesEmpty) {
+        case (cellUpdates, (c, index)) if c != ' ' =>
+          (index, Set(c.toString.toInt)) +: cellUpdates
+        case (cellUpdates, _) => cellUpdates
+      }
+
+    } yield (row, updates)
+
+
+  def readSudokuFromFile(sudokuInputFile: java.io.File): Vector[(Int, CellUpdates)] = {
+    val dataLines = new FileLineTraversable(sudokuInputFile).toVector
+    val cellsIn =
+      dataLines
+        .map { inputLine => """\|""".r replaceAllIn(inputLine, "")}     // Remove 3x3 separator character
+        .filter (_ != "---+---+---")              // Remove 3x3 line separator
+        .map ("""^[1-9 ]{9}$""".r findFirstIn(_)) // Input data should only contain values 1-9 or ' '
+        .collect { case Some(x) => x}
+        .zipWithIndex
+
+    convertFromCellsToComplete(cellsIn)
+  }
+}

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -1,0 +1,79 @@
+package org.lunatechlabs.dotty.sudoku
+
+import java.io.File
+
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
+import akka.actor.typed.{ActorRef, Behavior}
+
+object SudokuProblemSender {
+
+  enum Command {
+    case SendNewSudoku
+  }
+  export Command._
+
+  type CommandAndResponses = Command | SudokuSolver.Response
+
+  private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
+    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
+      .map((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
+
+  def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
+            sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
+    Behaviors.setup[CommandAndResponses] { context =>
+      Behaviors.withTimers { timers =>
+        new SudokuProblemSender(sudokuSolver, context, timers, sudokuSolverSettings).sending()
+      }
+    }.narrow // Restrict the actor's [external] protocol to its set of commands
+}
+
+class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
+                                   context: ActorContext[SudokuProblemSender.CommandAndResponses],
+                                   timers: TimerScheduler[SudokuProblemSender.CommandAndResponses],
+                                   sudokuSolverSettings: SudokuSolverSettings) {
+  import SudokuProblemSender._
+
+  private val initialSudokuField = rowUpdates.toSudokuField
+
+  private val rowUpdatesSeq = LazyList.continually(
+    Vector(
+      initialSudokuField,
+      initialSudokuField.flipVertically,
+      initialSudokuField.flipHorizontally,
+      initialSudokuField.flipHorizontally.flipVertically,
+      initialSudokuField.flipVertically.flipHorizontally,
+      initialSudokuField.columnSwap(0,1),
+      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
+      initialSudokuField.randomSwapAround,
+      initialSudokuField.randomSwapAround,
+      initialSudokuField.rotateCW,
+      initialSudokuField.rotateCCW,
+      initialSudokuField.rotateCW.rotateCW,
+      initialSudokuField.transpose,
+      initialSudokuField.randomSwapAround,
+      initialSudokuField.rotateCW.transpose,
+      initialSudokuField.randomSwapAround,
+      initialSudokuField.rotateCCW.transpose,
+      initialSudokuField.randomSwapAround,
+      initialSudokuField.randomSwapAround,
+      initialSudokuField.flipVertically.transpose,
+      initialSudokuField.flipVertically.rotateCW,
+      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
+      initialSudokuField.rotateCW.rotateCW.transpose
+    ).map(_.toRowUpdates)).flatten.iterator
+
+  private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
+  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+
+  def sending(): Behavior[CommandAndResponses] = Behaviors.receiveMessagePartial {
+    case SendNewSudoku =>
+      context.log.debug("sending new sudoku problem")
+      val nextRowUpdates = rowUpdatesSeq.next
+      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, context.self)
+      Behaviors.same
+    case solution: SudokuSolver.SudokuSolution =>
+      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+      Behaviors.same
+  }
+}
+

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,0 +1,50 @@
+package org.lunatechlabs.dotty.sudoku
+
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+import akka.actor.typed.{ActorRef, Behavior}
+
+object SudokuProgressTracker {
+
+  enum Command {
+    case NewUpdatesInFlight(count: Int)
+    case SudokuDetailState(index: Int, state: ReductionSet)
+  }
+  export Command._
+
+  // My responses
+  enum Response {
+    case Result(sudoku: Sudoku)
+  }
+  export Response._
+
+  def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+    Behaviors.setup { context =>
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+    }
+}
+
+class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+                            context: ActorContext[SudokuProgressTracker.Command],
+                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+
+  import SudokuProgressTracker._
+
+  def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessagePartial {
+    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+      rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
+      collectEndState()
+    case NewUpdatesInFlight(updateCount) =>
+      trackProgress(updatesInFlight + updateCount)
+  }
+
+  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+    Behaviors.receiveMessagePartial {
+      case detail @ SudokuDetailState(index, state) if remainingRows == 1 =>
+        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        trackProgress(updatesInFlight = 0)
+      case detail @ SudokuDetailState(index, state) =>
+        collectEndState(remainingRows = remainingRows - 1, detail +: endState)
+    }
+}
+

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -24,7 +24,7 @@ object SudokuSolver {
   export Response._
 
   type CommandAndResponses = Command | SudokuDetailProcessor.Response | SudokuProgressTracker.Response
-  
+
   import SudokuDetailProcessor.UpdateSender
 
   def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[CommandAndResponses]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
@@ -80,11 +80,11 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         updates.foreach { (rowCellNr, newCellContent) =>
 
             val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
-            val columnUpdate = Vector(columnCellNr -> newCellContent)
+            val columnUpdate = CellUpdates(columnCellNr -> newCellContent)
             columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, context.self)
 
             val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
-            val blockUpdate = Vector(blockCellNr -> newCellContent)
+            val blockUpdate = CellUpdates(blockCellNr -> newCellContent)
             blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, context.self)
         }
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
@@ -93,11 +93,11 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         updates.foreach { (colCellNr, newCellContent) =>
 
             val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
-            val rowUpdate = Vector(rowCellNr -> newCellContent)
+            val rowUpdate = CellUpdates(rowCellNr -> newCellContent)
             rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, context.self)
 
             val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
-            val blockUpdate = Vector(blockCellNr -> newCellContent)
+            val blockUpdate = CellUpdates(blockCellNr -> newCellContent)
             blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, context.self)
         }
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
@@ -106,11 +106,11 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         updates.foreach { (blockCellNr, newCellContent) =>
 
             val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
-            val rowUpdate = Vector(rowCellNr -> newCellContent)
+            val rowUpdate = CellUpdates(rowCellNr -> newCellContent)
             rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, context.self)
 
             val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
-            val columnUpdate = Vector(columnCellNr -> newCellContent)
+            val columnUpdate = CellUpdates(columnCellNr -> newCellContent)
             columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, context.self)
         }
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,0 +1,143 @@
+package org.lunatechlabs.dotty.sudoku
+
+import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
+import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+
+import scala.concurrent.duration._
+
+final case class SudokuField(sudoku: Sudoku)
+
+object SudokuSolver {
+
+  // SudokuSolver Protocol
+  enum Command {
+    case InitialRowUpdates(rowUpdates: Vector[SudokuDetailProcessor.RowUpdate],
+                                     replyTo: ActorRef[SudokuSolver.Response])
+  }
+  export Command._
+
+  // My Responses
+  enum Response {
+    case SudokuSolution(sudoku: Sudoku)
+  }
+  export Response._
+
+  type CommandAndResponses = Command | SudokuDetailProcessor.Response | SudokuProgressTracker.Response
+  
+  import SudokuDetailProcessor.UpdateSender
+
+  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[CommandAndResponses]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+    import scala.language.implicitConversions
+    cellIndexesVector.map {
+      index =>
+        val detailProcessorName = summon[UpdateSender[A]].processorName(index)
+        val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
+        (index, detailProcessor)
+    }.to(Map) // In Scala 2.13 this can be .to(Map)
+  }
+
+  def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
+    Behaviors.supervise[CommandAndResponses] {
+      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
+        Behaviors.setup { context =>
+          new SudokuSolver(context, buffer).idle()
+        }
+      }
+    }.onFailure[Exception](
+      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+    ).narrow
+}
+
+class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndResponses],
+                            buffer: StashBuffer[SudokuSolver.CommandAndResponses]) {
+  import CellMappings._
+  import SudokuSolver._
+
+  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val columnDetailProcessors = genDetailProcessors[Column](context)
+  private val blockDetailProcessors  = genDetailProcessors[Block](context)
+  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+
+  private val progressTracker =
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, context.self), "sudoku-progress-tracker")
+
+  def idle(): Behavior[CommandAndResponses] = Behaviors.receiveMessagePartial {
+
+    case InitialRowUpdates(rowUpdates, sender) =>
+      rowUpdates.foreach {
+        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, context.self)
+      }
+      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+      processRequest(Some(sender), System.currentTimeMillis())
+
+  }
+
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[CommandAndResponses] = Behaviors.receiveMessagePartial {
+    case response: SudokuDetailProcessor.Response => response match {
+      case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
+        updates.foreach { (rowCellNr, newCellContent) =>
+
+            val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
+            val columnUpdate = Vector(columnCellNr -> newCellContent)
+            columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, context.self)
+
+            val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
+            val blockUpdate = Vector(blockCellNr -> newCellContent)
+            blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, context.self)
+        }
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+        Behaviors.same
+      case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
+        updates.foreach { (colCellNr, newCellContent) =>
+
+            val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
+            val rowUpdate = Vector(rowCellNr -> newCellContent)
+            rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, context.self)
+
+            val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
+            val blockUpdate = Vector(blockCellNr -> newCellContent)
+            blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, context.self)
+        }
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+        Behaviors.same
+      case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
+        updates.foreach { (blockCellNr, newCellContent) =>
+
+            val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
+            val rowUpdate = Vector(rowCellNr -> newCellContent)
+            rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, context.self)
+
+            val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
+            val columnUpdate = Vector(columnCellNr -> newCellContent)
+            columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, context.self)
+        }
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+        Behaviors.same
+      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+        Behaviors.same
+    }
+    case result: SudokuProgressTracker.Response => result match {
+      case SudokuProgressTracker.Result(sudoku) =>
+        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
+        requestor.get ! SudokuSolution(sudoku)
+        resetAllDetailProcessors()
+        buffer.unstashAll(idle())
+    }
+    case msg: InitialRowUpdates if buffer.isFull =>
+      context.log.info(s"DROPPING REQUEST")
+      Behaviors.same
+    case msg: InitialRowUpdates =>
+      buffer.stash(msg)
+      Behaviors.same
+  }
+
+  private def resetAllDetailProcessors(): Unit = {
+    for {
+      processors <- allDetailProcessors
+      (_, processor) <- processors
+    } processor ! SudokuDetailProcessor.ResetSudokuDetailState
+  }
+}

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,0 +1,23 @@
+package org.lunatechlabs.dotty.sudoku
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+
+object SudokuSolverSettings {
+
+  def apply(configFile: String): SudokuSolverSettings =
+    new SudokuSolverSettings(ConfigFactory.load(configFile))
+}
+
+class SudokuSolverSettings(config: Config) {
+  object SudokuSolver {
+    val StashBufferSize: Int = config.getInt("sudoku-solver.solver-stash-buffer-size")
+  }
+
+  object ProblemSender {
+
+    val SendInterval: FiniteDuration =
+      Duration(config.getDuration("sudoku-solver.problem-sender.send-interval", Millis), Millis)
+  }
+}

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/TopLevelDefinitions.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/TopLevelDefinitions.scala
@@ -1,0 +1,83 @@
+package org.lunatechlabs.dotty.sudoku
+
+private val N = 9
+val CELLPossibleValues: Vector[Int] = (1 to N).toVector
+val cellIndexesVector: Vector[Int] = Vector.range(0, N)
+val initialCell: Set[Int] = Set.range(1, 10)
+
+type CellContent = Set[Int]
+type ReductionSet = Vector[CellContent]
+type Sudoku = Vector[ReductionSet]
+
+type CellUpdates = Vector[(Int, Set[Int])]
+val cellUpdatesEmpty = Vector.empty[(Int, Set[Int])]
+
+import SudokuDetailProcessor.RowUpdate
+
+def (update: Vector[SudokuDetailProcessor.RowUpdate]).toSudokuField: SudokuField = {
+  import scala.language.implicitConversions
+  val rows =
+        update
+          .map { case SudokuDetailProcessor.RowUpdate(id, cellUpdates) => (id, cellUpdates)}
+        .to(Map).withDefaultValue(cellUpdatesEmpty)
+      val sudoku = for {
+        (row, cellUpdates) <- Vector.range(0, 9).map(row => (row, rows(row)))
+        x = cellUpdates.to(Map).withDefaultValue(Set(0))
+        y = Vector.range(0, 9).map(n => x(n))
+        } yield y
+      SudokuField(sudoku)
+}
+
+// Collective Extensions:
+// define extension methods that share the same left-hand parameter type under a single extension instance.
+extension sudokuFieldOps on (sudokuField: SudokuField) {
+
+  def transpose: SudokuField = SudokuField(sudokuField.sudoku.transpose)
+
+  def rotateCW: SudokuField = SudokuField(sudokuField.sudoku.reverse.transpose)
+
+  def rotateCCW: SudokuField = SudokuField(sudokuField.sudoku.transpose.reverse)
+
+  def flipVertically: SudokuField = SudokuField(sudokuField.sudoku.reverse)
+
+  def flipHorizontally: SudokuField = sudokuField.rotateCW.flipVertically.rotateCCW
+
+  def rowSwap(row1: Int, row2: Int): SudokuField = {
+    SudokuField(
+          sudokuField.sudoku.zipWithIndex.map {
+          case (_, `row1`) => sudokuField.sudoku(row2)
+          case (_, `row2`) => sudokuField.sudoku(row1)
+          case (row, _) => row
+          }
+        )
+  }
+
+  def columnSwap(col1: Int, col2: Int): SudokuField = {
+    sudokuField.rotateCW.rowSwap(col1, col2).rotateCCW
+  }
+
+  def randomSwapAround: SudokuField = {
+    import scala.language.implicitConversions
+    val possibleCellValues = Vector(1,2,3,4,5,6,7,8,9)
+    // Generate a random swapping of cell values. A value 0 is used as a marker for a cell
+    // with an unknown value (i.e. it can still hold all values 0 through 9). As such
+    // a cell with value 0 should remain 0 which is why we add an entry to the generated
+    // Map to that effect
+    val shuffledValuesMap =
+      possibleCellValues.zip(scala.util.Random.shuffle(possibleCellValues)).to(Map) + (0 -> 0)
+    SudokuField(sudokuField.sudoku.map { row =>
+      row.map(cell => Set(shuffledValuesMap(cell.head)))
+    })
+  }
+
+  def toRowUpdates: Vector[SudokuDetailProcessor.RowUpdate] = {
+    sudokuField
+      .sudoku
+      .map(_.zipWithIndex)
+      .map(row => row.filterNot(_._1 == Set(0)))
+      .zipWithIndex.filter(_._1.nonEmpty)
+      .map { (c, i) =>
+        SudokuDetailProcessor.RowUpdate(i, c.map(_.swap))
+      }
+  }
+}

--- a/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/TopLevelDefinitions.scala
+++ b/exercise_009_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/TopLevelDefinitions.scala
@@ -1,5 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
+import scala.collection.Factory
+
 private val N = 9
 val CELLPossibleValues: Vector[Int] = (1 to N).toVector
 val cellIndexesVector: Vector[Int] = Vector.range(0, N)
@@ -9,8 +11,28 @@ type CellContent = Set[Int]
 type ReductionSet = Vector[CellContent]
 type Sudoku = Vector[ReductionSet]
 
-type CellUpdates = Vector[(Int, Set[Int])]
-val cellUpdatesEmpty = Vector.empty[(Int, Set[Int])]
+opaque type CellUpdates = Vector[(Int, Set[Int])]
+object CellUpdates {
+  def apply(updates: (Int, Set[Int])*): CellUpdates = Vector(updates: _*)
+}
+val cellUpdatesEmpty: CellUpdates = Vector.empty[(Int, Set[Int])]
+
+extension on (updates: CellUpdates) {
+
+  /**
+   * Optionally, given that we only use `to(Map)`, we can create a non-generic extension method
+   * For ex.: def toMap: Map[Int, Set[Int]] = updates.to(Map).withDefaultValue(Set(0))
+   */
+  def to[C1](factory: Factory[(Int, Set[Int]), C1]): C1 = updates.to(factory)
+
+  def foldLeft[B](z: B)(op: (B, (Int, Set[Int])) => B): B = updates.foldLeft(z)(op)
+
+  def foreach[U](f: ((Int, Set[Int])) => U): Unit = updates.foreach(f)
+
+  def size: Int = updates.size
+}
+
+def (update: (Int, Set[Int])) +: (updates: CellUpdates): CellUpdates = update +: updates
 
 import SudokuDetailProcessor.RowUpdate
 

--- a/exercise_009_opaque_type_aliases/src/test/resources/logback-test.xml
+++ b/exercise_009_opaque_type_aliases/src/test/resources/logback-test.xml
@@ -1,0 +1,36 @@
+<configuration>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>warn</level>
+        </filter>
+        <encoder>
+            <pattern>%date{HH:mm:ss} %-5level [%X{akkaSource}] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="file" class="ch.qos.logback.core.FileAppender">
+        <file>${coffee-house.log-file:-coffee-house.log}</file>
+        <encoder>
+            <pattern>%date{HH:mm:ss} %-5level [%X{akkaSource}] - %msg%n</pattern>
+        </encoder>
+    </appender>
+    
+    <logger name="akka" level="ERROR" />
+
+    <logger name="com.lightbend.training.coffeehouse" level="warn" additivity="false">
+        <appender-ref ref="console"/>
+        <appender-ref ref="file"/>
+    </logger>
+
+    <logger name="akka.actor.RepointableActorRef" level="warn" additivity="false">
+        <appender-ref ref="console"/>
+        <appender-ref ref="file"/>
+    </logger>
+
+    <root level="warn">
+        <appender-ref ref="console"/>
+        <appender-ref ref="file"/>
+    </root>
+
+</configuration>

--- a/exercise_009_opaque_type_aliases/src/test/scala/akkapi/cluster/sudoku/BaseAkkaSpec.scala
+++ b/exercise_009_opaque_type_aliases/src/test/scala/akkapi/cluster/sudoku/BaseAkkaSpec.scala
@@ -1,0 +1,11 @@
+package org.lunatechlabs.dotty.sudoku
+
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import org.scalatest.BeforeAndAfterAll
+
+abstract class BaseAkkaSpec extends BaseSpec with BeforeAndAfterAll {
+
+  val testKit: ActorTestKit = ActorTestKit()
+
+  override def afterAll(): Unit = testKit.shutdownTestKit()
+}

--- a/exercise_009_opaque_type_aliases/src/test/scala/akkapi/cluster/sudoku/BaseSpec.scala
+++ b/exercise_009_opaque_type_aliases/src/test/scala/akkapi/cluster/sudoku/BaseSpec.scala
@@ -1,0 +1,8 @@
+package org.lunatechlabs.dotty.sudoku
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+abstract class BaseSpec extends AnyWordSpec with Matchers {
+
+}

--- a/exercise_009_opaque_type_aliases/src/test/scala/akkapi/cluster/sudoku/CellMappingSpec.scala
+++ b/exercise_009_opaque_type_aliases/src/test/scala/akkapi/cluster/sudoku/CellMappingSpec.scala
@@ -1,0 +1,47 @@
+package org.lunatechlabs.dotty.sudoku
+
+import akkapi.cluster.sudoku.CellMappings._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CellMappingSpec extends AnyWordSpec with Matchers {
+
+  "Mapping row coordinates" should {
+    "result in correct column & block coordinates" in {
+      rowToColumnCoordinates(0, 0) shouldBe ((0, 0))
+      rowToBlockCoordinates(0, 0)  shouldBe ((0, 0))
+      rowToColumnCoordinates(8, 8) shouldBe ((8, 8))
+      rowToBlockCoordinates(8, 8)  shouldBe ((8, 8))
+      rowToColumnCoordinates(3, 4) shouldBe ((4, 3))
+      rowToBlockCoordinates(3, 4)  shouldBe ((4, 1))
+      rowToBlockCoordinates(4, 3)  shouldBe ((4, 3))
+    }
+  }
+
+  "Mapping column coordinates" should {
+    "result in correct row & block coordinates" in {
+      columnToRowCoordinates(0, 0)   shouldBe ((0, 0))
+      columnToBlockCoordinates(0, 0) shouldBe ((0, 0))
+      columnToRowCoordinates(8, 8)   shouldBe ((8, 8))
+      columnToBlockCoordinates(8, 8) shouldBe ((8, 8))
+      columnToRowCoordinates(3, 4)   shouldBe ((4, 3))
+      columnToBlockCoordinates(3, 4) shouldBe ((4, 3))
+      columnToBlockCoordinates(4, 3) shouldBe ((4, 1))
+    }
+  }
+
+  "Mapping block coordinates" should {
+    "result in correct row & column coordinates" in {
+      blockToRowCoordinates(0, 0)    shouldBe ((0, 0))
+      blockToColumnCoordinates(0, 0) shouldBe ((0, 0))
+      blockToRowCoordinates(8, 8)    shouldBe ((8, 8))
+      blockToColumnCoordinates(8, 8) shouldBe ((8, 8))
+      blockToRowCoordinates(4, 3)    shouldBe ((4, 3))
+      blockToColumnCoordinates(4, 3) shouldBe ((3, 4))
+      blockToRowCoordinates(3, 4)    shouldBe ((4, 1))
+      blockToColumnCoordinates(3, 4) shouldBe ((1, 4))
+      blockToRowCoordinates(5, 5)    shouldBe ((4, 8))
+      blockToColumnCoordinates(5, 5) shouldBe ((8, 4))
+    }
+  }
+}

--- a/exercise_009_opaque_type_aliases/src/test/scala/akkapi/cluster/sudoku/ReductionRuleSpec.scala
+++ b/exercise_009_opaque_type_aliases/src/test/scala/akkapi/cluster/sudoku/ReductionRuleSpec.scala
@@ -1,0 +1,191 @@
+package org.lunatechlabs.dotty.sudoku
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ReductionRuleSpec extends AnyWordSpec with Matchers with SudokuTestHelpers {
+  "Applying reduction rules" should {
+    "Eliminate values in isolated complete sets from occurrences in other cells (First reduction rule)" in {
+      /**
+       * Note: test data in this test is a "ReductionSet": is consists of 9 cells (e.g. in a
+       *       row or column or 3x3 block). Each cell is represented by 9 characters: a space
+       *       encodes a number not present in the cell, characters '1' through '9' encode the
+       *       presence of that digit in the cell.
+       */
+      val input = stringToReductionSet(Vector(
+        "12345678 ",
+        "1        ", // 1: Isolated & complete
+        "   4     ", // 4: Isolated & complete
+        "12 45678 ",
+        "      78 ", // (7,8): Isolated & complete
+        "       89",
+        "      78 ", // (7,8): Isolated & complete
+        "     6789",
+        " 23   78 "
+      ))
+
+      val reducedInput1 = stringToReductionSet(Vector(
+        " 23 56   ",
+        "1        ",
+        "   4     ",
+        " 2  56   ",
+        "      78 ",
+        "        9",
+        "      78 ",
+        "     6  9",
+        " 23      "
+      ))
+
+      applyReductionRules(input) shouldEqual reducedInput1
+
+      // After first reduction round, 9 is isolated & complete
+      val reducedInput2 = stringToReductionSet(Vector(
+        " 23 56   ",
+        "1        ",
+        "   4     ",
+        " 2  56   ",
+        "      78 ",
+        "        9",
+        "      78 ",
+        "     6   ",
+        " 23      "
+      ))
+
+      applyReductionRules(reducedInput1) shouldEqual reducedInput2
+
+      // After second reduction round, 6 is isolated & complete
+      val reducedInput3 = stringToReductionSet(Vector(
+        " 23 5    ",
+        "1        ",
+        "   4     ",
+        " 2  5    ",
+        "      78 ",
+        "        9",
+        "      78 ",
+        "     6   ",
+        " 23      "
+      ))
+
+      applyReductionRules(reducedInput2) shouldEqual reducedInput3
+
+      // reducing again should give same result
+      applyReductionRules(reducedInput3) shouldEqual reducedInput3
+    }
+
+    "Eliminate values in isolated complete sets of 5 values from occurrences in other cells (First reduction rule)" in {
+      val input = stringToReductionSet(Vector(
+        "12345    ", // (1,2,3,4,5): Isolated & complete
+        "1    67  ",
+        "12345    ", // (1,2,3,4,5): Isolated & complete
+        "12345    ", // (1,2,3,4,5): Isolated & complete
+        " 2    78 ",
+        "12345    ", // (1,2,3,4,5): Isolated & complete
+        "  3    89",
+        "12345    ", // (1,2,3,4,5): Isolated & complete
+        "1 3  6  9"
+      ))
+
+      val reducedInput = stringToReductionSet(Vector(
+        "12345    ",
+        "     67  ",
+        "12345    ",
+        "12345    ",
+        "      78 ",
+        "12345    ",
+        "       89",
+        "12345    ",
+        "     6  9"
+      ))
+
+      applyReductionRules(input) shouldEqual reducedInput
+
+    }
+
+    "Eliminate values in 2 isolated complete sets of 3 values from occurrences in other cells (First reduction rule)" in {
+      val input = stringToReductionSet(Vector(
+        "123      ",
+        "123      ",
+        "123      ",
+        "   456   ",
+        "   456   ",
+        "   456   ",
+        "12345678 ",
+        "123456 89",
+        "1234567 9"
+      ))
+
+      val reducedInput = stringToReductionSet(Vector(
+        "123      ",
+        "123      ",
+        "123      ",
+        "   456   ",
+        "   456   ",
+        "   456   ",
+        "      78 ",
+        "       89",
+        "      7 9"
+      ))
+
+      applyReductionRules(input) shouldEqual reducedInput
+    }
+
+    "Eliminate values in shadowed complete sets from occurrences in same cells (Second reduction rule)" in {
+      val input = stringToReductionSet(Vector(
+        "12  5 789", // (1,2,7,8) shadowed & complete
+        "  345    ", // (3,4)     shadowed & complete
+        "12  5678 ", // (1,2,7,8) shadowed & complete
+        "    56  9",
+        "    56  9",
+        "12    789", // (1,2,7,8) shadowed & complete
+        "  3456  9", // (3,4)     shadowed & complete
+        "12   6789", // (1,2,7,8) shadowed & complete
+        "        9"
+      ))
+
+      val reducedInput1 = stringToReductionSet(Vector(
+        "12    78 ",
+        "  34     ",
+        "12    78 ",
+        "    56   ",
+        "    56   ",
+        "12    78 ",
+        "  34     ",
+        "12    78 ",
+        "        9"
+      ))
+
+      applyReductionRules(input) shouldEqual reducedInput1
+
+      // reducing again gives same result
+      applyReductionRules(reducedInput1) shouldEqual reducedInput1
+    }
+
+    "Eliminate values in shadowed complete (6 value) sets from occurrences in same cells (Second reduction rule)" in {
+      val input = stringToReductionSet(Vector(
+        "123456 89", // (1,2,3,4,5,6) shadowed & complete
+        "      78 ",
+        "12345678 ", // (1,2,3,4,5,6) shadowed & complete
+        "123456789", // (1,2,3,4,5,6) shadowed & complete
+        "123456 8 ", // (1,2,3,4,5,6) shadowed & complete
+        "       89",
+        "123456 8 ", // (1,2,3,4,5,6) shadowed & complete
+        "      7 9",
+        "12345678 "  // (1,2,3,4,5,6) shadowed & complete
+      ))
+
+      val reducedInput = stringToReductionSet(Vector(
+        "123456   ",
+        "      78 ",
+        "123456   ",
+        "123456   ",
+        "123456   ",
+        "       89",
+        "123456   ",
+        "      7 9",
+        "123456   "
+      ))
+
+      applyReductionRules(input) shouldEqual reducedInput
+    }
+  }
+}

--- a/exercise_009_opaque_type_aliases/src/test/scala/akkapi/cluster/sudoku/SudokuDetailProcessorSpec.scala
+++ b/exercise_009_opaque_type_aliases/src/test/scala/akkapi/cluster/sudoku/SudokuDetailProcessorSpec.scala
@@ -1,0 +1,123 @@
+package org.lunatechlabs.dotty.sudoku
+
+import SudokuDetailProcessor.{Update, SudokuDetailUnchanged, BlockUpdate}
+
+class SudokuDetailProcessorSpec extends BaseAkkaSpec with SudokuTestHelpers {
+
+  "Sending no updates to a sudoku detail processor" should {
+    "result in sending a SudokuDetailUnchanged messsage" in {
+
+      val probe = testKit.createTestProbe[SudokuDetailProcessor.Response]()
+      val detailProcessor = testKit.spawn(SudokuDetailProcessor[Row](id = 0))
+      detailProcessor ! Update(cellUpdatesEmpty, probe.ref)
+      probe.expectMessage(SudokuDetailUnchanged)
+    }
+  }
+
+  "Sending an update to a fresh instance of the SudokuDetailProcessor that sets one cell to a single value" should {
+    "result in sending an update that reflects this update" in {
+      val probe = testKit.createTestProbe[SudokuDetailProcessor.Response]()
+      val detailProcessor = testKit.spawn(SudokuDetailProcessor[Row](id = 0))
+      detailProcessor ! Update(List((4, Set(7))), probe.ref)
+
+      val expectedState1 =
+        SudokuDetailProcessor.RowUpdate(0, stringToIndexedUpdate(
+          Vector(
+            "123456 89",
+            "123456 89",
+            "123456 89",
+            "123456 89",
+            "      7  ",
+            "123456 89",
+            "123456 89",
+            "123456 89",
+            "123456 89"
+          ))
+        )
+
+      probe.expectMessage(expectedState1)
+    }
+  }
+
+  "Sending a series of subsequent Updates to a SudokuDetailProcessor" should {
+    "result in sending updates and ultimately return no changes" in {
+      val detailParentProbe = testKit.createTestProbe[SudokuDetailProcessor.Response]()
+      val detailProcessor = testKit.spawn(SudokuDetailProcessor[Block](id = 2))
+
+      val update1 =
+        Update(stringToReductionSet(Vector(
+          "12345678 ",
+          "1        ", // 1: Isolated & complete
+          "   4     ", // 4: Isolated & complete
+          "12 45678 ",
+          "      78 ", // (7,8): Isolated & complete
+          "       89",
+          "      78 ", // (7,8): Isolated & complete
+          "     6789",
+          " 23   78 "
+        )).zipWithIndex.map { _.swap},
+          detailParentProbe.ref
+        )
+
+      detailProcessor ! update1
+
+      val reducedUpdate1 = BlockUpdate(2, stringToReductionSet(Vector(
+        " 23 56   ",
+        "1        ",
+        "   4     ",
+        " 2  56   ",
+        "      78 ",
+        "        9",
+        "      78 ",
+        "     6  9",
+        " 23      "
+      )).zipWithIndex.map(_.swap)
+      )
+
+      detailParentProbe.expectMessage(reducedUpdate1)
+
+      detailProcessor ! Update(cellUpdatesEmpty, detailParentProbe.ref)
+
+      val reducedUpdate2 =
+        BlockUpdate(2, stringToIndexedUpdate(
+          Vector(
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "     6   ",
+            ""
+          ))
+        )
+
+      detailParentProbe.expectMessage(reducedUpdate2)
+
+      detailProcessor ! Update(cellUpdatesEmpty, detailParentProbe.ref)
+
+      val reducedUpdate3 =
+        BlockUpdate(2, stringToIndexedUpdate(
+          Vector(
+            " 23 5    ",
+            "",
+            "",
+            " 2  5    ",
+            "",
+            "",
+            "",
+            "",
+            ""
+          ))
+        )
+
+      detailParentProbe.expectMessage(reducedUpdate3)
+
+      detailProcessor ! Update(cellUpdatesEmpty, detailParentProbe.ref)
+
+      detailParentProbe.expectMessage(SudokuDetailUnchanged)
+
+    }
+  }
+}

--- a/exercise_009_opaque_type_aliases/src/test/scala/akkapi/cluster/sudoku/SudokuTestHelpers.scala
+++ b/exercise_009_opaque_type_aliases/src/test/scala/akkapi/cluster/sudoku/SudokuTestHelpers.scala
@@ -1,0 +1,21 @@
+package org.lunatechlabs.dotty.sudoku
+
+trait SudokuTestHelpers {
+
+  import akkapi.cluster.sudoku.ReductionRules.{reductionRuleOne, reductionRuleTwo}
+
+  def stringToReductionSet(stringDef: Vector[String]): ReductionSet = {
+    for {
+      cellString <- stringDef
+    } yield cellString.replaceAll(" ", "").map { _.toString.toInt }.toSet
+  }
+
+  def stringToIndexedUpdate(stringDef: Vector[String]): CellUpdates = {
+    for {
+      (cellString, index) <- stringDef.zipWithIndex if cellString != ""
+    } yield (index, cellString.replaceAll(" ", "").map { _.toString.toInt }.toSet)
+  }
+
+  def applyReductionRules(reductionSet: ReductionSet): ReductionSet = reductionRuleTwo(reductionRuleOne(reductionSet))
+
+}


### PR DESCRIPTION
This is an exercise to introduce the topic of Opaque Type Aliases. Students will be asked to convert the existing plain type alias `CellUpdates` into an Opaque Type Alias.

This PR:
- Adds `exercise_009_opaque_type_aliases` sub-project based off the code of `exercise_008_union_types`
- Changes `CellUpdates` to an opaque type and makes other necessary changes for the project to compile
- Adds a README
