### PR TITLE
Fix setting of compiler option '-language:strictEquality'

### DIFF
--- a/exercise_010_multiversal_equality/build.sbt
+++ b/exercise_010_multiversal_equality/build.sbt
@@ -1,0 +1,1 @@
+scalacOptions in Compile += "-language:strictEquality"

--- a/project/CompileOptions.scala
+++ b/project/CompileOptions.scala
@@ -29,8 +29,6 @@ object CompileOptions {
   val compileOptions = Seq(
     "-unchecked",
     "-deprecation",
-    "-language:_",
     "-encoding", "UTF-8",
-    "-language:strictEquality"
   )
 }


### PR DESCRIPTION
- The setting was applied to all exercises, which causes compilation
  to fail on exercises preceding the one on Multiversal Equality
- Applied the setting to the exercise on Multiversal Equality only