### PR TITLE
Add the strictEquality flag only to the multiversal-equality sub-project

### DIFF
--- a/exercise_010_multiversal_equality/README.md
+++ b/exercise_010_multiversal_equality/README.md
@@ -26,10 +26,11 @@ found, then the comparison does not type-check and the compilation fails with an
 error.
 
 ## Steps
-- Open the `project/CompilerOptions.scala` file. There you should see a sequence
-  of enabled compiler flags.
-- Add the flag `-language:strictEquality`, reload SBT and re-compile the current
-  project
+- Create a new file `exercise_010_multiversal_equality/build.sbt`
+- Add the code `scalacOptions in Compile += "-language:strictEquality"` to opt
+  in to safer multiversal equality
+- Reload SBT, make sure you are in the `exercise_010_multiversal_equality`
+  project, and re-compile
 - Use the course notes on Multiversal Equality and your experience from the
   exercise on `given`s to make the code compile with the flag
   `-language:strictEquality` enabled

--- a/exercise_010_multiversal_equality/build.sbt
+++ b/exercise_010_multiversal_equality/build.sbt
@@ -1,0 +1,1 @@
+scalacOptions in Compile += "-language:strictEquality"

--- a/project/CompileOptions.scala
+++ b/project/CompileOptions.scala
@@ -29,7 +29,6 @@ object CompileOptions {
   val compileOptions = Seq(
     "-unchecked",
     "-deprecation",
-    "-language:_",
     "-encoding", "UTF-8"
   )
 }

--- a/project/CompileOptions.scala
+++ b/project/CompileOptions.scala
@@ -30,7 +30,6 @@ object CompileOptions {
     "-unchecked",
     "-deprecation",
     "-language:_",
-    "-encoding", "UTF-8",
-    "-language:strictEquality"
+    "-encoding", "UTF-8"
   )
 }


### PR DESCRIPTION
This stops the flag affecting other exercises.

This PR also updates the README for the exercise.