### PR TITLE
Improvement: dottyVersion in ThisBuild

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val `scala-2-to-scala-3-master` = (project in file("."))
     `exercise_009_opaque_type_aliases`,
     `exercise_010_multiversal_equality`
  )
-  .settings(scalaVersion in ThisBuild := CommonSettings.dottyVersion)
+  .settings(scalaVersion in ThisBuild := Version.dottyVersion)
  .settings(CommonSettings.commonSettings: _*)
 
 lazy val common = project

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import sbt._
 
-val dottyVersion = "0.24.0-RC1"
 
 lazy val `scala-2-to-scala-3-master` = (project in file("."))
   .aggregate(
@@ -16,7 +15,7 @@ lazy val `scala-2-to-scala-3-master` = (project in file("."))
     `exercise_009_opaque_type_aliases`,
     `exercise_010_multiversal_equality`
  )
-  .settings(scalaVersion in ThisBuild := dottyVersion)
+  .settings(scalaVersion in ThisBuild := CommonSettings.dottyVersion)
  .settings(CommonSettings.commonSettings: _*)
 
 lazy val common = project

--- a/build.sbt
+++ b/build.sbt
@@ -16,59 +16,48 @@ lazy val `scala-2-to-scala-3-master` = (project in file("."))
     `exercise_009_opaque_type_aliases`,
     `exercise_010_multiversal_equality`
  )
-  .settings(scalaVersion := dottyVersion)
+  .settings(scalaVersion in ThisBuild := dottyVersion)
  .settings(CommonSettings.commonSettings: _*)
 
 lazy val common = project
-  .settings(scalaVersion := dottyVersion)
   .settings(CommonSettings.commonSettings: _*)
 
 lazy val `exercise_000_clustered_sudoku_solver_initial_state` = project
-  .settings(scalaVersion := dottyVersion)
   .configure(CommonSettings.configure)
   .dependsOn(common % "test->test;compile->compile")
 
 lazy val `exercise_002_top_level_definitions` = project
-  .settings(scalaVersion := dottyVersion)
   .configure(CommonSettings.configure)
   .dependsOn(common % "test->test;compile->compile")
 
 lazy val `exercise_003_parameter_untupling` = project
-  .settings(scalaVersion := dottyVersion)
   .configure(CommonSettings.configure)
   .dependsOn(common % "test->test;compile->compile")
 
 lazy val `exercise_004_extension_methods` = project
-  .settings(scalaVersion := dottyVersion)
   .configure(CommonSettings.configure)
   .dependsOn(common % "test->test;compile->compile")
 
 lazy val `exercise_005_using_and_summon` = project
-  .settings(scalaVersion := dottyVersion)
   .configure(CommonSettings.configure)
   .dependsOn(common % "test->test;compile->compile")
 
 lazy val `exercise_006_givens` = project
-  .settings(scalaVersion := dottyVersion)
   .configure(CommonSettings.configure)
   .dependsOn(common % "test->test;compile->compile")
 
 lazy val `exercise_007_enum_and_export` = project
-  .settings(scalaVersion := dottyVersion)
   .configure(CommonSettings.configure)
   .dependsOn(common % "test->test;compile->compile")
 
 lazy val `exercise_008_union_types` = project
-  .settings(scalaVersion := dottyVersion)
   .configure(CommonSettings.configure)
   .dependsOn(common % "test->test;compile->compile")
 
 lazy val `exercise_009_opaque_type_aliases` = project
-  .settings(scalaVersion := dottyVersion)
   .configure(CommonSettings.configure)
   .dependsOn(common % "test->test;compile->compile")
 
 lazy val `exercise_010_multiversal_equality` = project
-  .settings(scalaVersion := dottyVersion)
   .configure(CommonSettings.configure)
   .dependsOn(common % "test->test;compile->compile")

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val `scala-2-to-scala-3-master` = (project in file("."))
     `exercise_009_opaque_type_aliases`,
     `exercise_010_multiversal_equality`
  )
-  .settings(scalaVersion in ThisBuild := Version.dottyVersion)
+  .settings(scalaVersion in ThisBuild := Version.scalaVersion)
  .settings(CommonSettings.commonSettings: _*)
 
 lazy val common = project

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -49,4 +49,6 @@ object CommonSettings {
   lazy val configure: Project => Project = (project: Project) => {
     project.settings(CommonSettings.commonSettings: _*)
   }
+
+  val dottyVersion = "0.24.0-RC1"
 }

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -49,6 +49,4 @@ object CommonSettings {
   lazy val configure: Project => Project = (project: Project) => {
     project.settings(CommonSettings.commonSettings: _*)
   }
-
-  val dottyVersion = "0.24.0-RC1"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,10 +26,11 @@ object Version {
   val logbackVer        = "1.2.3"
   val akkaManagementVer = "1.0.6"
   val scalaTestVer      = "3.1.1"
+  val dottyVersion = "0.24.0-RC1"
 }
 
 object Dependencies {
-  
+
   private val akkaDeps = Seq(
     "com.typesafe.akka"             %% "akka-actor-typed",
     "com.typesafe.akka"             %% "akka-slf4j",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Version {
   val logbackVer        = "1.2.3"
   val akkaManagementVer = "1.0.6"
   val scalaTestVer      = "3.1.1"
-  val dottyVersion = "0.24.0-RC1"
+  val scalaVersion = "0.24.0-RC1"
 }
 
 object Dependencies {

--- a/project/MPSelection.scala
+++ b/project/MPSelection.scala
@@ -102,6 +102,7 @@ object MPSelection {
          |    common,
          |${exercises.mkString("    ", ",\n    ", "")}
          | )
+         |  .settings(scalaVersion in ThisBuild := CommonSettings.dottyVersion)
          |  .settings(CommonSettings.commonSettings: _*)
          |${if (multiJVM)
            s"""  .settings(SbtMultiJvm.multiJvmSettings: _*)

--- a/project/MPSelection.scala
+++ b/project/MPSelection.scala
@@ -102,7 +102,7 @@ object MPSelection {
          |    common,
          |${exercises.mkString("    ", ",\n    ", "")}
          | )
-         |  .settings(scalaVersion in ThisBuild := Version.dottyVersion)
+         |  .settings(scalaVersion in ThisBuild := Version.scalaVersion)
          |  .settings(CommonSettings.commonSettings: _*)
          |${if (multiJVM)
            s"""  .settings(SbtMultiJvm.multiJvmSettings: _*)

--- a/project/MPSelection.scala
+++ b/project/MPSelection.scala
@@ -102,7 +102,7 @@ object MPSelection {
          |    common,
          |${exercises.mkString("    ", ",\n    ", "")}
          | )
-         |  .settings(scalaVersion in ThisBuild := CommonSettings.dottyVersion)
+         |  .settings(scalaVersion in ThisBuild := Version.dottyVersion)
          |  .settings(CommonSettings.commonSettings: _*)
          |${if (multiJVM)
            s"""  .settings(SbtMultiJvm.multiJvmSettings: _*)


### PR DESCRIPTION
When one selects a project to work with via `setActiveExerciseNo` the fresh `build.sbt` has no `scalaVersion` set up, this it falls back to Scala 2.12. With the proposed improvement:
* `dottyVersion` belongs to `CommonSettings`
* `scalaVersion` is set at the aggregate project level with `ThisBuild` so is propagated to all the aggregated projects.