### PR TITLE
Amend context bounds and summon example

### DIFF
--- a/code-snippets/contextual-abstractions/src/main/scala/org/lunatech/dotty/givens/SummonSample.scala
+++ b/code-snippets/contextual-abstractions/src/main/scala/org/lunatech/dotty/givens/SummonSample.scala
@@ -8,12 +8,12 @@ trait Starter[T] {
   def start(e: T): Unit
 }
 
-given Starter[CarEngine] = new {
+given Starter[CarEngine] {
   override def start(engine: CarEngine): Unit = 
     println(s"Starting CarEngine with ${engine.cylinder} cylinder(s)")
 }
 
-given Starter[TruckEngine] = new {
+given Starter[TruckEngine] {
   override def start(engine: TruckEngine): Unit = 
     println(s"Starting TruckEngine with ${engine.cylinder} cylinder(s)")
 }
@@ -27,4 +27,5 @@ def startEngine[E <: Engine: Starter](engine: E): Unit = {
 
   startEngine(CarEngine(6))
   startEngine(TruckEngine(8))
+  startEngine(TruckEngine(1))(using summon[Starter[TruckEngine]])
 }


### PR DESCRIPTION
- Switch to more concise syntax for type class instance definition
- Add another example on passing a type class instance to a method