### PR TITLE
Switch to exact matching on messages

### DIFF
--- a/exercises/.gitignore
+++ b/exercises/.gitignore
@@ -1,0 +1,1 @@
+../.gitignore

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -61,7 +61,7 @@ class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] priva
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
     case Update(cellUpdates, replyTo) if ! fullyReduced =>
       val previousState = state
       val updatedState = mergeState(state, cellUpdates)

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -66,7 +66,7 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
   timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def sending(): Behavior[Command] = Behaviors.receiveMessage {
     case SendNewSudoku =>
       context.log.debug("sending new sudoku problem")
       val nextRowUpdates = rowUpdatesSeq.next

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -25,21 +25,27 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
 
   import SudokuProgressTracker._
 
-  def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessagePartial {
+   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
     case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
       rowDetailProcessors.foreach { case (_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self) }
       collectEndState()
     case NewUpdatesInFlight(updateCount) =>
       trackProgress(updatesInFlight + updateCount)
+    case msg: SudokuDetailState =>
+      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+      Behaviors.same
   }
 
   def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
         sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
+      case msg: NewUpdatesInFlight =>
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
+        Behaviors.same
     }
 }
 

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -61,7 +61,7 @@ class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] priva
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
     case Update(cellUpdates, replyTo) if ! fullyReduced =>
       val previousState = state
       val updatedState = mergeState(state, cellUpdates)

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -66,7 +66,7 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
   timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def sending(): Behavior[Command] = Behaviors.receiveMessage {
     case SendNewSudoku =>
       context.log.debug("sending new sudoku problem")
       val nextRowUpdates = rowUpdatesSeq.next

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -25,21 +25,27 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
 
   import SudokuProgressTracker._
 
-  def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessagePartial {
+   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
     case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
       rowDetailProcessors.foreach { case (_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self) }
       collectEndState()
     case NewUpdatesInFlight(updateCount) =>
       trackProgress(updatesInFlight + updateCount)
+    case msg: SudokuDetailState =>
+      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+      Behaviors.same
   }
 
   def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
         sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
+      case msg: NewUpdatesInFlight =>
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
+        Behaviors.same
     }
 }
 

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -61,7 +61,7 @@ class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] priva
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
     case Update(cellUpdates, replyTo) if ! fullyReduced =>
       val previousState = state
       val updatedState = mergeState(state, cellUpdates)

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -66,7 +66,7 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
   timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def sending(): Behavior[Command] = Behaviors.receiveMessage {
     case SendNewSudoku =>
       context.log.debug("sending new sudoku problem")
       val nextRowUpdates = rowUpdatesSeq.next

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -25,21 +25,27 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
 
   import SudokuProgressTracker._
 
-  def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessagePartial {
+   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
     case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
       rowDetailProcessors.foreach { case (_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self) }
       collectEndState()
     case NewUpdatesInFlight(updateCount) =>
       trackProgress(updatesInFlight + updateCount)
+    case msg: SudokuDetailState =>
+      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+      Behaviors.same
   }
 
   def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
         sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
+      case msg: NewUpdatesInFlight =>
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
+        Behaviors.same
     }
 }
 

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -61,7 +61,7 @@ class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] priva
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
     case Update(cellUpdates, replyTo) if ! fullyReduced =>
       val previousState = state
       val updatedState = mergeState(state, cellUpdates)

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -66,7 +66,7 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
   timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def sending(): Behavior[Command] = Behaviors.receiveMessage {
     case SendNewSudoku =>
       context.log.debug("sending new sudoku problem")
       val nextRowUpdates = rowUpdatesSeq.next

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -25,21 +25,27 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
 
   import SudokuProgressTracker._
 
-  def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessagePartial {
+   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
     case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
       rowDetailProcessors.foreach { case (_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self) }
       collectEndState()
     case NewUpdatesInFlight(updateCount) =>
       trackProgress(updatesInFlight + updateCount)
+    case msg: SudokuDetailState =>
+      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+      Behaviors.same
   }
 
   def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
         sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
+      case msg: NewUpdatesInFlight =>
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
+        Behaviors.same
     }
 }
 

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -61,7 +61,7 @@ class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] priva
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
     case Update(cellUpdates, replyTo) if ! fullyReduced =>
       val previousState = state
       val updatedState = mergeState(state, cellUpdates)

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -66,7 +66,7 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
   timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def sending(): Behavior[Command] = Behaviors.receiveMessage {
     case SendNewSudoku =>
       context.log.debug("sending new sudoku problem")
       val nextRowUpdates = rowUpdatesSeq.next

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -63,7 +63,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   private val progressTracker =
     context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def idle(): Behavior[Command] = Behaviors.receiveMessage {
 
     case InitialRowUpdates(rowUpdates, sender) =>
       rowUpdates.foreach {
@@ -72,10 +72,13 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
       }
       progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
       processRequest(Some(sender), System.currentTimeMillis())
+    case unexpectedMsg =>
+      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
+      Behaviors.same
 
   }
 
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
     case SudokuDetailProcessorResponseWrapped(response) => response match {
       case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
         updates.foreach { (rowCellNr, newCellContent) =>

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -60,7 +60,7 @@ class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] priva
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
     case Update(cellUpdates, replyTo) if ! fullyReduced =>
       val previousState = state
       val updatedState = mergeState(state, cellUpdates)

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -66,7 +66,7 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
   timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def sending(): Behavior[Command] = Behaviors.receiveMessage {
     case SendNewSudoku =>
       context.log.debug("sending new sudoku problem")
       val nextRowUpdates = rowUpdatesSeq.next

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -63,7 +63,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   private val progressTracker =
     context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def idle(): Behavior[Command] = Behaviors.receiveMessage {
 
     case InitialRowUpdates(rowUpdates, sender) =>
       rowUpdates.foreach {
@@ -72,10 +72,13 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
       }
       progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
       processRequest(Some(sender), System.currentTimeMillis())
+    case unexpectedMsg =>
+      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
+      Behaviors.same
 
   }
 
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
     case SudokuDetailProcessorResponseWrapped(response) => response match {
       case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
         updates.foreach { (rowCellNr, newCellContent) =>

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -60,7 +60,7 @@ class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] priva
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
     case Update(cellUpdates, replyTo) if ! fullyReduced =>
       val previousState = state
       val updatedState = mergeState(state, cellUpdates)

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -66,7 +66,7 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
   timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def sending(): Behavior[Command] = Behaviors.receiveMessage {
     case SendNewSudoku =>
       context.log.debug("sending new sudoku problem")
       val nextRowUpdates = rowUpdatesSeq.next

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -63,7 +63,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   private val progressTracker =
     context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def idle(): Behavior[Command] = Behaviors.receiveMessage {
 
     case InitialRowUpdates(rowUpdates, sender) =>
       rowUpdates.foreach {
@@ -72,10 +72,13 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
       }
       progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
       processRequest(Some(sender), System.currentTimeMillis())
+    case unexpectedMsg =>
+      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
+      Behaviors.same
 
   }
 
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
     case SudokuDetailProcessorResponseWrapped(response) => response match {
       case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
         updates.foreach { (rowCellNr, newCellContent) =>

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -60,7 +60,7 @@ class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] priva
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
     case Update(cellUpdates, replyTo) if ! fullyReduced =>
       val previousState = state
       val updatedState = mergeState(state, cellUpdates)

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -66,7 +66,7 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
   timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def sending(): Behavior[Command] = Behaviors.receiveMessage {
     case SendNewSudoku =>
       context.log.debug("sending new sudoku problem")
       val nextRowUpdates = rowUpdatesSeq.next

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -63,7 +63,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   private val progressTracker =
     context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def idle(): Behavior[Command] = Behaviors.receiveMessage {
 
     case InitialRowUpdates(rowUpdates, sender) =>
       rowUpdates.foreach {
@@ -72,10 +72,13 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
       }
       progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
       processRequest(Some(sender), System.currentTimeMillis())
+    case unexpectedMsg =>
+      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
+      Behaviors.same
 
   }
 
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
     case SudokuDetailProcessorResponseWrapped(response) => response match {
       case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
         updates.foreach { (rowCellNr, newCellContent) =>

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -64,7 +64,7 @@ class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] priva
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
     case Update(cellUpdates, replyTo) if ! fullyReduced =>
       val previousState = state
       val updatedState = mergeState(state, cellUpdates)

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -70,7 +70,7 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
   timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def sending(): Behavior[Command] = Behaviors.receiveMessage {
     case SendNewSudoku =>
       context.log.debug("sending new sudoku problem")
       val nextRowUpdates = rowUpdatesSeq.next

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -30,21 +30,27 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
 
   import SudokuProgressTracker._
 
-  def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessagePartial {
+   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
     case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
       rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
       collectEndState()
     case NewUpdatesInFlight(updateCount) =>
       trackProgress(updatesInFlight + updateCount)
+    case msg: SudokuDetailState =>
+      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+      Behaviors.same
   }
 
   def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
         sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
+      case msg: NewUpdatesInFlight =>
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
+        Behaviors.same
     }
 }
 

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -68,7 +68,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   private val progressTracker =
     context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def idle(): Behavior[Command] = Behaviors.receiveMessage {
 
     case InitialRowUpdates(rowUpdates, sender) =>
       rowUpdates.foreach {
@@ -77,10 +77,13 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
       }
       progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
       processRequest(Some(sender), System.currentTimeMillis())
+    case unexpectedMsg =>
+      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
+      Behaviors.same
 
   }
 
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessagePartial {
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
     case SudokuDetailProcessorResponseWrapped(response) => response match {
       case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
         updates.foreach { (rowCellNr, newCellContent) =>

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -64,7 +64,7 @@ class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] priva
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
     case Update(cellUpdates, replyTo) if ! fullyReduced =>
       val previousState = state
       val updatedState = mergeState(state, cellUpdates)

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -65,7 +65,7 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
   timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[CommandAndResponses] = Behaviors.receiveMessagePartial {
+  def sending(): Behavior[CommandAndResponses] = Behaviors.receiveMessage {
     case SendNewSudoku =>
       context.log.debug("sending new sudoku problem")
       val nextRowUpdates = rowUpdatesSeq.next

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -30,21 +30,27 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
 
   import SudokuProgressTracker._
 
-  def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessagePartial {
+   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
     case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
       rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
       collectEndState()
     case NewUpdatesInFlight(updateCount) =>
       trackProgress(updatesInFlight + updateCount)
+    case msg: SudokuDetailState =>
+      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+      Behaviors.same
   }
 
   def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
         sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
+      case msg: NewUpdatesInFlight =>
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
+        Behaviors.same
     }
 }
 

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -64,7 +64,7 @@ class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] priva
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
     case Update(cellUpdates, replyTo) if ! fullyReduced =>
       val previousState = state
       val updatedState = mergeState(state, cellUpdates)

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -65,7 +65,7 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
   timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[CommandAndResponses] = Behaviors.receiveMessagePartial {
+  def sending(): Behavior[CommandAndResponses] = Behaviors.receiveMessage {
     case SendNewSudoku =>
       context.log.debug("sending new sudoku problem")
       val nextRowUpdates = rowUpdatesSeq.next

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -30,21 +30,27 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
 
   import SudokuProgressTracker._
 
-  def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessagePartial {
+   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
     case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
       rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
       collectEndState()
     case NewUpdatesInFlight(updateCount) =>
       trackProgress(updatesInFlight + updateCount)
+    case msg: SudokuDetailState =>
+      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+      Behaviors.same
   }
 
   def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
         sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
+      case msg: NewUpdatesInFlight =>
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
+        Behaviors.same
     }
 }
 

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -64,7 +64,7 @@ class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] priva
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
     case Update(cellUpdates, replyTo) if ! fullyReduced =>
       val previousState = state
       val updatedState = mergeState(state, cellUpdates)

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -65,7 +65,7 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
   timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[CommandAndResponses] = Behaviors.receiveMessagePartial {
+  def sending(): Behavior[CommandAndResponses] = Behaviors.receiveMessage {
     case SendNewSudoku =>
       context.log.debug("sending new sudoku problem")
       val nextRowUpdates = rowUpdatesSeq.next

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -30,21 +30,27 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
 
   import SudokuProgressTracker._
 
-  def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessagePartial {
+   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
     case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
       rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
       collectEndState()
     case NewUpdatesInFlight(updateCount) =>
       trackProgress(updatesInFlight + updateCount)
+    case msg: SudokuDetailState =>
+      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+      Behaviors.same
   }
 
   def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
-    Behaviors.receiveMessagePartial {
+    Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
         sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
+      case msg: NewUpdatesInFlight =>
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
+        Behaviors.same
     }
 }
 


### PR DESCRIPTION
Switch to exact matching on messages
- Swap utilisation of `receiveMessagePartial` to `receiveMessage` as this is
  a better practice in general and it can be used to demonstrate exactly that
- In a state machine, this swap is less obvious as it now requires matching
  on messages that cannot be received in some states. It's required to eliminate
  compiler warnings. Somewhat artificial and open to discussion/personal taste