### PR TITLE
Reformat code & remove redundant code/Bump versions

### DIFF
--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -22,26 +22,29 @@ package org.lunatechlabs.dotty
 
 import akka.NotUsed
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
-import akka.actor.typed.scaladsl.{Behaviors, Routers}
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
-import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import akka.actor.typed.{ ActorSystem, Behavior, Terminated }
+import org.lunatechlabs.dotty.sudoku.{ SudokuProblemSender, SudokuSolver, SudokuSolverSettings }
 
-import scala.Console.{GREEN, RESET}
+import scala.Console.{ GREEN, RESET }
 import scala.io.StdIn
 
 object Main {
-  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
-    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
-    // Start a SodukuSolver
-    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
-    // Start a Sudoku problem sender
-    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+  def apply(): Behavior[NotUsed] =
+    Behaviors.setup { context =>
+      val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+      // Start a SodukuSolver
+      val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+      // Start a Sudoku problem sender
+      context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings),
+                    "sudoku-problem-sender"
+      )
 
-    Behaviors.receiveSignal {
-      case (_, Terminated(_)) =>
-        Behaviors.stopped
+      Behaviors.receiveSignal {
+        case (_, Terminated(_)) =>
+          Behaviors.stopped
+      }
     }
-  }
 }
 
 object SudokuSolverMain {

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -15,8 +15,8 @@ object CellMappings {
     rowToBlockCoordinates(cellNr, columnNr)
 
   def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+    ((blockNr / 3) * 3 + cellNr / 3, (blockNr % 3) * 3 + cellNr % 3)
 
   def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+    ((blockNr % 3) * 3 + cellNr % 3, (blockNr / 3) * 3 + cellNr / 3)
 }

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -3,15 +3,16 @@ package org.lunatechlabs.dotty.sudoku
 object ReductionRules {
 
   def reductionRuleOne(reductionSet: ReductionSet): ReductionSet = {
-    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
-    val completeInputCellGroups = inputCellsGrouped filter {
+    val inputCellsGrouped = reductionSet.filter(_.size <= 7).groupBy(identity)
+    val completeInputCellGroups = inputCellsGrouped.filter {
       case (set, setOccurrences) => set.size == setOccurrences.length
     }
     val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
     completeAndIsolatedValueSets.foldLeft(reductionSet) {
-      case (cells, caivSet) => cells.map {
-        cell => if (cell != caivSet) cell &~ caivSet else cell
-      }
+      case (cells, caivSet) =>
+        cells.map { cell =>
+          if (cell != caivSet) cell &~ caivSet else cell
+        }
     }
   }
 
@@ -24,9 +25,10 @@ object ReductionRules {
     }
 
     val cellIndexesToValues =
-      CELLPossibleValues.zip(valueOccurrences)
-        .groupBy { case (value, occurrence) => occurrence}
-        .filter  { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
+      CELLPossibleValues
+        .zip(valueOccurrences)
+        .groupBy { case (value, occurrence) => occurrence }
+        .filter { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
 
     val cellIndexListToReducedValue = cellIndexesToValues.map {
       case (index, seq) => (index, (seq.map { case (value, _) => value }).toSet)
@@ -34,7 +36,7 @@ object ReductionRules {
 
     val cellIndexToReducedValue = cellIndexListToReducedValue.flatMap {
       case (cellIndexList, reducedValue) =>
-        cellIndexList.map ( cellIndex => cellIndex -> reducedValue )
+        cellIndexList.map(cellIndex => cellIndex -> reducedValue)
     }
 
     reductionSet.zipWithIndex.foldRight(Vector.empty[CellContent]) {

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 import org.lunatechlabs.dotty.sudoku.SudokuDetailProcessor.UpdateSender
 
 object SudokuDetailProcessor {
@@ -10,7 +10,8 @@ object SudokuDetailProcessor {
   sealed trait Command
   case object ResetSudokuDetailState extends Command
   final case class Update(cellUpdates: CellUpdates, replyTo: ActorRef[Response]) extends Command
-  final case class GetSudokuDetailState(replyTo: ActorRef[SudokuProgressTracker.Command]) extends Command
+  final case class GetSudokuDetailState(replyTo: ActorRef[SudokuProgressTracker.Command])
+      extends Command
 
   // My responses
   sealed trait Response
@@ -21,94 +22,93 @@ object SudokuDetailProcessor {
 
   val InitialDetailState: ReductionSet = cellIndexesVector.map(_ => initialCell)
 
-  def apply[DetailType <: SudokoDetailType](id: Int,
-                                            state: ReductionSet = InitialDetailState)
-                                           (implicit updateSender: UpdateSender[DetailType]): Behavior[Command] = {
+  def apply[DetailType <: SudokoDetailType](id: Int, state: ReductionSet = InitialDetailState)(
+    implicit updateSender: UpdateSender[DetailType]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
       (new SudokuDetailProcessor[DetailType](context)).operational(id, state, fullyReduced = false)
     }
-  }
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit
-
     def processorName(id: Int): String
   }
 
   implicit val rowUpdateSender: UpdateSender[Row] = new UpdateSender[Row] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit = {
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! RowUpdate(id, cellUpdates)
-    }
-    override def processorName(id: Int): String = s"row-processor-$id"
+    def processorName(id: Int): String = s"row-processor-$id"
   }
 
   implicit val columnUpdateSender: UpdateSender[Column] = new UpdateSender[Column] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"col-processor-$id"
+    def processorName(id: Int): String = s"col-processor-$id"
   }
 
   implicit val blockUpdateSender: UpdateSender[Block] = new UpdateSender[Block] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! BlockUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"blk-processor-$id"
+    def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 
-class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] private (context: ActorContext[SudokuDetailProcessor.Command]) {
+class SudokuDetailProcessor[DetailType <: SudokoDetailType: UpdateSender] private (
+  context: ActorContext[SudokuDetailProcessor.Command]
+) {
 
-  import ReductionRules.{reductionRuleOne, reductionRuleTwo}
+  import ReductionRules.{ reductionRuleOne, reductionRuleTwo }
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
     Behaviors.receiveMessage {
-    case Update(cellUpdates, replyTo) if ! fullyReduced =>
-      val previousState = state
-      val updatedState = mergeState(state, cellUpdates)
-      if (updatedState == previousState && cellUpdates != cellUpdatesEmpty) {
-        replyTo ! SudokuDetailUnchanged
-        Behaviors.same
-      } else {
-        val transformedUpdatedState = reductionRuleTwo(reductionRuleOne(updatedState))
-        if (transformedUpdatedState == state) {
+      case Update(cellUpdates, replyTo) if !fullyReduced =>
+        val previousState = state
+        val updatedState = mergeState(state, cellUpdates)
+        if (updatedState == previousState && cellUpdates != cellUpdatesEmpty) {
           replyTo ! SudokuDetailUnchanged
           Behaviors.same
-        } else {
-          val updateSender = implicitly[UpdateSender[DetailType]]
-          updateSender.sendUpdate(id, stateChanges(state, transformedUpdatedState))(replyTo)
-          operational(id, transformedUpdatedState, isFullyReduced(transformedUpdatedState))
         }
-      }
+        else {
+          val transformedUpdatedState = reductionRuleTwo(reductionRuleOne(updatedState))
+          if (transformedUpdatedState == state) {
+            replyTo ! SudokuDetailUnchanged
+            Behaviors.same
+          }
+          else {
+            val updateSender = implicitly[UpdateSender[DetailType]]
+            updateSender.sendUpdate(id, stateChanges(state, transformedUpdatedState))(replyTo)
+            operational(id, transformedUpdatedState, isFullyReduced(transformedUpdatedState))
+          }
+        }
 
-    case Update(cellUpdates, replyTo) =>
-      replyTo ! SudokuDetailUnchanged
-      Behaviors.same
+      case Update(cellUpdates, replyTo) =>
+        replyTo ! SudokuDetailUnchanged
+        Behaviors.same
 
-    case GetSudokuDetailState(replyTo) =>
-      replyTo ! SudokuProgressTracker.SudokuDetailState(id, state)
-      Behaviors.same
+      case GetSudokuDetailState(replyTo) =>
+        replyTo ! SudokuProgressTracker.SudokuDetailState(id, state)
+        Behaviors.same
 
-    case ResetSudokuDetailState =>
-      operational(id, InitialDetailState, fullyReduced = false)
+      case ResetSudokuDetailState =>
+        operational(id, InitialDetailState, fullyReduced = false)
 
-  }
+    }
 
-  private def mergeState(state: ReductionSet, cellUpdates: CellUpdates): ReductionSet = {
-      cellUpdates.foldLeft(state) {
+  private def mergeState(state: ReductionSet, cellUpdates: CellUpdates): ReductionSet =
+    cellUpdates.foldLeft(state) {
       case (stateTally, (index, updatedCellContent)) =>
         stateTally.updated(index, stateTally(index) & updatedCellContent)
     }
-  }
 
-  private def stateChanges(state: ReductionSet, updatedState: ReductionSet): CellUpdates = {
-    (state zip updatedState).zipWithIndex.foldRight(cellUpdatesEmpty) {
+  private def stateChanges(state: ReductionSet, updatedState: ReductionSet): CellUpdates =
+    state.zip(updatedState).zipWithIndex.foldRight(cellUpdatesEmpty) {
       case (((previousCellContent, updatedCellContent), index), cellUpdates)
-        if updatedCellContent != previousCellContent =>
+          if updatedCellContent != previousCellContent =>
         (index, updatedCellContent) +: cellUpdates
 
       case (_, cellUpdates) => cellUpdates
     }
-  }
 
   private def isFullyReduced(state: ReductionSet): Boolean = {
     val allValuesInState = state.flatten

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -2,8 +2,8 @@ package org.lunatechlabs.dotty.sudoku
 
 import java.io.File
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProblemSender {
 
@@ -13,11 +13,13 @@ object SudokuProblemSender {
   private final case class SolutionWrapper(result: SudokuSolver.Response) extends Command
 
   private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
-    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
+    SudokuIO
+      .readSudokuFromFile(new File("sudokus/001.sudoku"))
       .map { case (rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update) }
 
   def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
-            sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
+            sudokuSolverSettings: SudokuSolverSettings
+  ): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
         new SudokuProblemSender(sudokuSolver, context, timers, sudokuSolverSettings).sending()
@@ -28,7 +30,8 @@ object SudokuProblemSender {
 class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
                                    context: ActorContext[SudokuProblemSender.Command],
                                    timers: TimerScheduler[SudokuProblemSender.Command],
-                                   sudokuSolverSettings: SudokuSolverSettings) {
+                                   sudokuSolverSettings: SudokuSolverSettings
+) {
   import SudokuProblemSender._
 
   private val solutionWrapper: ActorRef[SudokuSolver.Response] =
@@ -36,45 +39,51 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
 
   private val initialSudokuField = rowUpdates.toSudokuField
 
-  private val rowUpdatesSeq = LazyList.continually(
-    Vector(
-      initialSudokuField,
-      initialSudokuField.flipVertically,
-      initialSudokuField.flipHorizontally,
-      initialSudokuField.flipHorizontally.flipVertically,
-      initialSudokuField.flipVertically.flipHorizontally,
-      initialSudokuField.columnSwap(0,1),
-      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW,
-      initialSudokuField.rotateCCW,
-      initialSudokuField.rotateCW.rotateCW,
-      initialSudokuField.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.flipVertically.transpose,
-      initialSudokuField.flipVertically.rotateCW,
-      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
-      initialSudokuField.rotateCW.rotateCW.transpose
-    ).map(_.toRowUpdates)).flatten.iterator
+  private val rowUpdatesSeq = LazyList
+    .continually(
+      Vector(
+        initialSudokuField,
+        initialSudokuField.flipVertically,
+        initialSudokuField.flipHorizontally,
+        initialSudokuField.flipHorizontally.flipVertically,
+        initialSudokuField.flipVertically.flipHorizontally,
+        initialSudokuField.columnSwap(0, 1),
+        initialSudokuField.rowSwap(4, 5).rowSwap(0, 2),
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW,
+        initialSudokuField.rotateCCW,
+        initialSudokuField.rotateCW.rotateCW,
+        initialSudokuField.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.flipVertically.transpose,
+        initialSudokuField.flipVertically.rotateCW,
+        initialSudokuField.columnSwap(4, 5).columnSwap(0, 2).rowSwap(3, 4),
+        initialSudokuField.rotateCW.rotateCW.transpose
+      ).map(_.toRowUpdates)
+    )
+    .flatten
+    .iterator
 
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
-  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+  timers.startTimerAtFixedRate(SendNewSudoku,
+                               problemSendInterval
+  ) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessage {
-    case SendNewSudoku =>
-      context.log.debug("sending new sudoku problem")
-      val nextRowUpdates = rowUpdatesSeq.next
-      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
-      Behaviors.same
-    case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
-      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
-      Behaviors.same
-  }
+  def sending(): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SendNewSudoku =>
+        context.log.debug("sending new sudoku problem")
+        val nextRowUpdates = rowUpdatesSeq.next
+        sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
+        Behaviors.same
+      case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
+        context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+        Behaviors.same
+    }
 }
-

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProgressTracker {
 
@@ -13,33 +13,47 @@ object SudokuProgressTracker {
   final case class Result(sudoku: Sudoku) extends Response
 
   def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+            sudokuSolver: ActorRef[Response]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
-      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver)
+        .trackProgress(updatesInFlight = 0)
     }
 }
 
-class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-                            context: ActorContext[SudokuProgressTracker.Command],
-                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+class SudokuProgressTracker private (
+  rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+  context: ActorContext[SudokuProgressTracker.Command],
+  sudokuSolver: ActorRef[SudokuProgressTracker.Response]
+) {
 
   import SudokuProgressTracker._
 
-   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
-    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
-      rowDetailProcessors.foreach { case (_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self) }
-      collectEndState()
-    case NewUpdatesInFlight(updateCount) =>
-      trackProgress(updatesInFlight + updateCount)
-    case msg: SudokuDetailState =>
-      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-      Behaviors.same
-  }
+  def trackProgress(updatesInFlight: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+        rowDetailProcessors.foreach {
+          case (_, processor) =>
+            processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self)
+        }
+        collectEndState()
+      case NewUpdatesInFlight(updateCount) =>
+        trackProgress(updatesInFlight + updateCount)
+      case msg: SudokuDetailState =>
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+        Behaviors.same
+    }
 
-  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+  def collectEndState(remainingRows: Int = 9,
+                      endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]
+  ): Behavior[Command] =
     Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
-        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        sudokuSolver ! Result(
+          (detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map {
+            case SudokuDetailState(_, state) => state
+          }
+        )
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
@@ -48,4 +62,3 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
         Behaviors.same
     }
 }
-

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 
 import scala.concurrent.duration._
 
@@ -13,40 +13,53 @@ object SudokuSolver {
   // SudokuSolver Protocol
   sealed trait Command
   final case class InitialRowUpdates(rowUpdates: Vector[SudokuDetailProcessor.RowUpdate],
-                                     replyTo: ActorRef[SudokuSolver.Response]) extends Command
+                                     replyTo: ActorRef[SudokuSolver.Response]
+  ) extends Command
   // Wrapped responses
-  private final case class SudokuDetailProcessorResponseWrapped(response: SudokuDetailProcessor.Response) extends Command
-  private final case class SudokuProgressTrackerResponseWrapped(response: SudokuProgressTracker.Response) extends Command
+  private final case class SudokuDetailProcessorResponseWrapped(
+    response: SudokuDetailProcessor.Response
+  ) extends Command
+  private final case class SudokuProgressTrackerResponseWrapped(
+    response: SudokuProgressTracker.Response
+  ) extends Command
   // My Responses
   sealed trait Response
   final case class SudokuSolution(sudoku: Sudoku) extends Response
 
   import SudokuDetailProcessor.UpdateSender
 
-  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[Command]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+  def genDetailProcessors[A <: SudokoDetailType: UpdateSender](
+    context: ActorContext[Command]
+  ): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
     import scala.language.implicitConversions
-    cellIndexesVector.map {
-      index =>
+    cellIndexesVector
+      .map { index =>
         val detailProcessorName = implicitly[UpdateSender[A]].processorName(index)
         val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
         (index, detailProcessor)
-    }.to(Map) // In Scala 2.13 this can be .to(Map)
+      }
+      .to(Map)
   }
 
   def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
-    Behaviors.supervise[Command] {
-      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
-        Behaviors.setup { context =>
-          new SudokuSolver(context, buffer).idle()
+    Behaviors
+      .supervise[Command] {
+        Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) {
+          buffer =>
+            Behaviors.setup { context =>
+              new SudokuSolver(context, buffer).idle()
+            }
         }
       }
-    }.onFailure[Exception](
-      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
-    )
+      .onFailure[Exception](
+        SupervisorStrategy
+          .restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+      )
 }
 
 class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
-                            buffer: StashBuffer[SudokuSolver.Command]) {
+                            buffer: StashBuffer[SudokuSolver.Command]
+) {
   import CellMappings._
   import SudokuSolver._
 
@@ -55,96 +68,101 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   val progressTrackerResponseMapper: ActorRef[SudokuProgressTracker.Response] =
     context.messageAdapter(response => SudokuProgressTrackerResponseWrapped(response))
 
-  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val rowDetailProcessors = genDetailProcessors[Row](context)
   private val columnDetailProcessors = genDetailProcessors[Column](context)
-  private val blockDetailProcessors  = genDetailProcessors[Block](context)
-  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+  private val blockDetailProcessors = genDetailProcessors[Block](context)
+  private val allDetailProcessors =
+    List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
 
   private val progressTracker =
-    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper),
+                  "sudoku-progress-tracker"
+    )
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessage {
+  def idle(): Behavior[Command] =
+    Behaviors.receiveMessage {
 
-    case InitialRowUpdates(rowUpdates, sender) =>
-      rowUpdates.foreach {
-        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
-          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
-      }
-      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
-      processRequest(Some(sender), System.currentTimeMillis())
-    case unexpectedMsg =>
-      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-      Behaviors.same
-
-  }
-
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
-    case SudokuDetailProcessorResponseWrapped(response) => response match {
-      case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
-        updates.foreach {
-          case (rowCellNr, newCellContent) =>
-
-            val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
-            val columnUpdate = Vector(columnCellNr -> newCellContent)
-            columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
-
-            val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
-            val blockUpdate = Vector(blockCellNr -> newCellContent)
-            blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+      case InitialRowUpdates(rowUpdates, sender) =>
+        rowUpdates.foreach {
+          case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+            rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+        processRequest(Some(sender), System.currentTimeMillis())
+      case unexpectedMsg =>
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
-      case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
-        updates.foreach {
-          case (colCellNr, newCellContent) =>
 
-            val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
-            val rowUpdate = Vector(rowCellNr -> newCellContent)
-            rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+    }
 
-            val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
-            val blockUpdate = Vector(blockCellNr -> newCellContent)
-            blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SudokuDetailProcessorResponseWrapped(response) =>
+        response match {
+          case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
+            updates.foreach {
+              case (rowCellNr, newCellContent) =>
+                val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
+                val columnUpdate = Vector(columnCellNr -> newCellContent)
+                columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+
+                val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
+                val blockUpdate = Vector(blockCellNr -> newCellContent)
+                blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
+            updates.foreach {
+              case (colCellNr, newCellContent) =>
+                val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
+                val rowUpdate = Vector(rowCellNr -> newCellContent)
+                rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+                val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
+                val blockUpdate = Vector(blockCellNr -> newCellContent)
+                blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
+            updates.foreach {
+              case (blockCellNr, newCellContent) =>
+                val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
+                val rowUpdate = Vector(rowCellNr -> newCellContent)
+                rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+                val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
+                val columnUpdate = Vector(columnCellNr -> newCellContent)
+                columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case unchanged @ SudokuDetailProcessor.SudokuDetailUnchanged =>
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+            Behaviors.same
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
-        Behaviors.same
-      case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
-        updates.foreach {
-          case (blockCellNr, newCellContent) =>
-
-            val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
-            val rowUpdate = Vector(rowCellNr -> newCellContent)
-            rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
-
-            val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
-            val columnUpdate = Vector(columnCellNr -> newCellContent)
-            columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+      case SudokuProgressTrackerResponseWrapped(result) =>
+        result match {
+          case SudokuProgressTracker.Result(sudoku) =>
+            context.log.info(
+              s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds"
+            )
+            requestor.get ! SudokuSolution(sudoku)
+            resetAllDetailProcessors()
+            buffer.unstashAll(idle())
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+      case msg: InitialRowUpdates if buffer.isFull =>
+        context.log.info(s"DROPPING REQUEST")
         Behaviors.same
-      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+      case msg: InitialRowUpdates =>
+        buffer.stash(msg)
         Behaviors.same
     }
-    case SudokuProgressTrackerResponseWrapped(result) => result match {
-      case SudokuProgressTracker.Result(sudoku) =>
-        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
-        requestor.get ! SudokuSolution(sudoku)
-        resetAllDetailProcessors()
-        buffer.unstashAll(idle())
-    }
-    case msg: InitialRowUpdates if buffer.isFull =>
-      context.log.info(s"DROPPING REQUEST")
-      Behaviors.same
-    case msg: InitialRowUpdates =>
-      buffer.stash(msg)
-      Behaviors.same
-  }
 
-  private def resetAllDetailProcessors(): Unit = {
+  private def resetAllDetailProcessors(): Unit =
     for {
       processors <- allDetailProcessors
       (_, processor) <- processors
     } processor ! SudokuDetailProcessor.ResetSudokuDetailState
-  }
 }

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS => Millis }
 
 object SudokuSolverSettings {
 

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/package.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/package.scala
@@ -16,13 +16,15 @@ package object sudoku {
 
   import SudokuDetailProcessor.RowUpdate
 
-  implicit class RowUpdatesToSudokuField(val update: Vector[SudokuDetailProcessor.RowUpdate]) extends AnyVal {
+  implicit class RowUpdatesToSudokuField(val update: Vector[SudokuDetailProcessor.RowUpdate])
+      extends AnyVal {
     import scala.language.implicitConversions
     def toSudokuField: SudokuField = {
       val rows =
         update
-          .map { case SudokuDetailProcessor.RowUpdate(id, cellUpdates) => (id, cellUpdates)}
-          .to(Map).withDefaultValue(cellUpdatesEmpty)
+          .map { case SudokuDetailProcessor.RowUpdate(id, cellUpdates) => (id, cellUpdates) }
+          .to(Map)
+          .withDefaultValue(cellUpdatesEmpty)
       val sudoku = for {
         (row, cellUpdates) <- Vector.range(0, 9).map(row => (row, rows(row)))
         x = cellUpdates.to(Map).withDefaultValue(Set(0))
@@ -43,23 +45,21 @@ package object sudoku {
 
     def flipHorizontally: SudokuField = sudokuField.rotateCW.flipVertically.rotateCCW
 
-    def rowSwap(row1: Int, row2: Int): SudokuField = {
+    def rowSwap(row1: Int, row2: Int): SudokuField =
       SudokuField(
         sudokuField.sudoku.zipWithIndex.map {
-        case (_, `row1`) => sudokuField.sudoku(row2)
-        case (_, `row2`) => sudokuField.sudoku(row1)
-        case (row, _) => row
+          case (_, `row1`) => sudokuField.sudoku(row2)
+          case (_, `row2`) => sudokuField.sudoku(row1)
+          case (row, _) => row
         }
       )
-    }
 
-    def columnSwap(col1: Int, col2: Int): SudokuField = {
+    def columnSwap(col1: Int, col2: Int): SudokuField =
       sudokuField.rotateCW.rowSwap(col1, col2).rotateCCW
-    }
 
     def randomSwapAround: SudokuField = {
       import scala.language.implicitConversions
-      val possibleCellValues = Vector(1,2,3,4,5,6,7,8,9)
+      val possibleCellValues = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9)
       // Generate a random swapping of cell values. A value 0 is used as a marker for a cell
       // with an unknown value (i.e. it can still hold all values 0 through 9). As such
       // a cell with value 0 should remain 0 which is why we add an entry to the generated
@@ -71,15 +71,15 @@ package object sudoku {
       })
     }
 
-    def toRowUpdates: Vector[RowUpdate] = {
-      sudokuField
-        .sudoku
+    def toRowUpdates: Vector[RowUpdate] =
+      sudokuField.sudoku
         .map(_.zipWithIndex)
         .map(row => row.filterNot(_._1 == Set(0)))
-        .zipWithIndex.filter(_._1.nonEmpty)
-        .map { case (c, i) =>
-          RowUpdate(i, c.map(_.swap))
+        .zipWithIndex
+        .filter(_._1.nonEmpty)
+        .map {
+          case (c, i) =>
+            RowUpdate(i, c.map(_.swap))
         }
-    }
   }
 }

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -22,26 +22,29 @@ package org.lunatechlabs.dotty
 
 import akka.NotUsed
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
-import akka.actor.typed.scaladsl.{Behaviors, Routers}
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
-import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import akka.actor.typed.{ ActorSystem, Behavior, Terminated }
+import org.lunatechlabs.dotty.sudoku.{ SudokuProblemSender, SudokuSolver, SudokuSolverSettings }
 
-import scala.Console.{GREEN, RESET}
+import scala.Console.{ GREEN, RESET }
 import scala.io.StdIn
 
 object Main {
-  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
-    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
-    // Start a SodukuSolver
-    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
-    // Start a Sudoku problem sender
-    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+  def apply(): Behavior[NotUsed] =
+    Behaviors.setup { context =>
+      val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+      // Start a SodukuSolver
+      val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+      // Start a Sudoku problem sender
+      context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings),
+                    "sudoku-problem-sender"
+      )
 
-    Behaviors.receiveSignal {
-      case (_, Terminated(_)) =>
-        Behaviors.stopped
+      Behaviors.receiveSignal {
+        case (_, Terminated(_)) =>
+          Behaviors.stopped
+      }
     }
-  }
 }
 
 object SudokuSolverMain {

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -15,8 +15,8 @@ object CellMappings {
     rowToBlockCoordinates(cellNr, columnNr)
 
   def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+    ((blockNr / 3) * 3 + cellNr / 3, (blockNr % 3) * 3 + cellNr % 3)
 
   def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+    ((blockNr % 3) * 3 + cellNr % 3, (blockNr / 3) * 3 + cellNr / 3)
 }

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -3,15 +3,16 @@ package org.lunatechlabs.dotty.sudoku
 object ReductionRules {
 
   def reductionRuleOne(reductionSet: ReductionSet): ReductionSet = {
-    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
-    val completeInputCellGroups = inputCellsGrouped filter {
+    val inputCellsGrouped = reductionSet.filter(_.size <= 7).groupBy(identity)
+    val completeInputCellGroups = inputCellsGrouped.filter {
       case (set, setOccurrences) => set.size == setOccurrences.length
     }
     val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
     completeAndIsolatedValueSets.foldLeft(reductionSet) {
-      case (cells, caivSet) => cells.map {
-        cell => if (cell != caivSet) cell &~ caivSet else cell
-      }
+      case (cells, caivSet) =>
+        cells.map { cell =>
+          if (cell != caivSet) cell &~ caivSet else cell
+        }
     }
   }
 
@@ -24,9 +25,10 @@ object ReductionRules {
     }
 
     val cellIndexesToValues =
-      CELLPossibleValues.zip(valueOccurrences)
-        .groupBy { case (value, occurrence) => occurrence}
-        .filter  { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
+      CELLPossibleValues
+        .zip(valueOccurrences)
+        .groupBy { case (value, occurrence) => occurrence }
+        .filter { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
 
     val cellIndexListToReducedValue = cellIndexesToValues.map {
       case (index, seq) => (index, (seq.map { case (value, _) => value }).toSet)
@@ -34,7 +36,7 @@ object ReductionRules {
 
     val cellIndexToReducedValue = cellIndexListToReducedValue.flatMap {
       case (cellIndexList, reducedValue) =>
-        cellIndexList.map ( cellIndex => cellIndex -> reducedValue )
+        cellIndexList.map(cellIndex => cellIndex -> reducedValue)
     }
 
     reductionSet.zipWithIndex.foldRight(Vector.empty[CellContent]) {

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 import org.lunatechlabs.dotty.sudoku.SudokuDetailProcessor.UpdateSender
 
 object SudokuDetailProcessor {
@@ -10,7 +10,8 @@ object SudokuDetailProcessor {
   sealed trait Command
   case object ResetSudokuDetailState extends Command
   final case class Update(cellUpdates: CellUpdates, replyTo: ActorRef[Response]) extends Command
-  final case class GetSudokuDetailState(replyTo: ActorRef[SudokuProgressTracker.Command]) extends Command
+  final case class GetSudokuDetailState(replyTo: ActorRef[SudokuProgressTracker.Command])
+      extends Command
 
   // My responses
   sealed trait Response
@@ -21,94 +22,93 @@ object SudokuDetailProcessor {
 
   val InitialDetailState: ReductionSet = cellIndexesVector.map(_ => initialCell)
 
-  def apply[DetailType <: SudokoDetailType](id: Int,
-                                            state: ReductionSet = InitialDetailState)
-                                           (implicit updateSender: UpdateSender[DetailType]): Behavior[Command] = {
+  def apply[DetailType <: SudokoDetailType](id: Int, state: ReductionSet = InitialDetailState)(
+    implicit updateSender: UpdateSender[DetailType]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
       (new SudokuDetailProcessor[DetailType](context)).operational(id, state, fullyReduced = false)
     }
-  }
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit
-
     def processorName(id: Int): String
   }
 
   implicit val rowUpdateSender: UpdateSender[Row] = new UpdateSender[Row] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit = {
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! RowUpdate(id, cellUpdates)
-    }
-    override def processorName(id: Int): String = s"row-processor-$id"
+    def processorName(id: Int): String = s"row-processor-$id"
   }
 
   implicit val columnUpdateSender: UpdateSender[Column] = new UpdateSender[Column] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"col-processor-$id"
+    def processorName(id: Int): String = s"col-processor-$id"
   }
 
   implicit val blockUpdateSender: UpdateSender[Block] = new UpdateSender[Block] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! BlockUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"blk-processor-$id"
+    def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 
-class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] private (context: ActorContext[SudokuDetailProcessor.Command]) {
+class SudokuDetailProcessor[DetailType <: SudokoDetailType: UpdateSender] private (
+  context: ActorContext[SudokuDetailProcessor.Command]
+) {
 
-  import ReductionRules.{reductionRuleOne, reductionRuleTwo}
+  import ReductionRules.{ reductionRuleOne, reductionRuleTwo }
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
     Behaviors.receiveMessage {
-    case Update(cellUpdates, replyTo) if ! fullyReduced =>
-      val previousState = state
-      val updatedState = mergeState(state, cellUpdates)
-      if (updatedState == previousState && cellUpdates != cellUpdatesEmpty) {
-        replyTo ! SudokuDetailUnchanged
-        Behaviors.same
-      } else {
-        val transformedUpdatedState = reductionRuleTwo(reductionRuleOne(updatedState))
-        if (transformedUpdatedState == state) {
+      case Update(cellUpdates, replyTo) if !fullyReduced =>
+        val previousState = state
+        val updatedState = mergeState(state, cellUpdates)
+        if (updatedState == previousState && cellUpdates != cellUpdatesEmpty) {
           replyTo ! SudokuDetailUnchanged
           Behaviors.same
-        } else {
-          val updateSender = implicitly[UpdateSender[DetailType]]
-          updateSender.sendUpdate(id, stateChanges(state, transformedUpdatedState))(replyTo)
-          operational(id, transformedUpdatedState, isFullyReduced(transformedUpdatedState))
         }
-      }
+        else {
+          val transformedUpdatedState = reductionRuleTwo(reductionRuleOne(updatedState))
+          if (transformedUpdatedState == state) {
+            replyTo ! SudokuDetailUnchanged
+            Behaviors.same
+          }
+          else {
+            val updateSender = implicitly[UpdateSender[DetailType]]
+            updateSender.sendUpdate(id, stateChanges(state, transformedUpdatedState))(replyTo)
+            operational(id, transformedUpdatedState, isFullyReduced(transformedUpdatedState))
+          }
+        }
 
-    case Update(cellUpdates, replyTo) =>
-      replyTo ! SudokuDetailUnchanged
-      Behaviors.same
+      case Update(cellUpdates, replyTo) =>
+        replyTo ! SudokuDetailUnchanged
+        Behaviors.same
 
-    case GetSudokuDetailState(replyTo) =>
-      replyTo ! SudokuProgressTracker.SudokuDetailState(id, state)
-      Behaviors.same
+      case GetSudokuDetailState(replyTo) =>
+        replyTo ! SudokuProgressTracker.SudokuDetailState(id, state)
+        Behaviors.same
 
-    case ResetSudokuDetailState =>
-      operational(id, InitialDetailState, fullyReduced = false)
+      case ResetSudokuDetailState =>
+        operational(id, InitialDetailState, fullyReduced = false)
 
-  }
+    }
 
-  private def mergeState(state: ReductionSet, cellUpdates: CellUpdates): ReductionSet = {
-      cellUpdates.foldLeft(state) {
+  private def mergeState(state: ReductionSet, cellUpdates: CellUpdates): ReductionSet =
+    cellUpdates.foldLeft(state) {
       case (stateTally, (index, updatedCellContent)) =>
         stateTally.updated(index, stateTally(index) & updatedCellContent)
     }
-  }
 
-  private def stateChanges(state: ReductionSet, updatedState: ReductionSet): CellUpdates = {
-    (state zip updatedState).zipWithIndex.foldRight(cellUpdatesEmpty) {
+  private def stateChanges(state: ReductionSet, updatedState: ReductionSet): CellUpdates =
+    state.zip(updatedState).zipWithIndex.foldRight(cellUpdatesEmpty) {
       case (((previousCellContent, updatedCellContent), index), cellUpdates)
-        if updatedCellContent != previousCellContent =>
+          if updatedCellContent != previousCellContent =>
         (index, updatedCellContent) +: cellUpdates
 
       case (_, cellUpdates) => cellUpdates
     }
-  }
 
   private def isFullyReduced(state: ReductionSet): Boolean = {
     val allValuesInState = state.flatten

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -2,8 +2,8 @@ package org.lunatechlabs.dotty.sudoku
 
 import java.io.File
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProblemSender {
 
@@ -13,11 +13,13 @@ object SudokuProblemSender {
   private final case class SolutionWrapper(result: SudokuSolver.Response) extends Command
 
   private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
-    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
+    SudokuIO
+      .readSudokuFromFile(new File("sudokus/001.sudoku"))
       .map { case (rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update) }
 
   def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
-            sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
+            sudokuSolverSettings: SudokuSolverSettings
+  ): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
         new SudokuProblemSender(sudokuSolver, context, timers, sudokuSolverSettings).sending()
@@ -28,7 +30,8 @@ object SudokuProblemSender {
 class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
                                    context: ActorContext[SudokuProblemSender.Command],
                                    timers: TimerScheduler[SudokuProblemSender.Command],
-                                   sudokuSolverSettings: SudokuSolverSettings) {
+                                   sudokuSolverSettings: SudokuSolverSettings
+) {
   import SudokuProblemSender._
 
   private val solutionWrapper: ActorRef[SudokuSolver.Response] =
@@ -36,45 +39,51 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
 
   private val initialSudokuField = rowUpdates.toSudokuField
 
-  private val rowUpdatesSeq = LazyList.continually(
-    Vector(
-      initialSudokuField,
-      initialSudokuField.flipVertically,
-      initialSudokuField.flipHorizontally,
-      initialSudokuField.flipHorizontally.flipVertically,
-      initialSudokuField.flipVertically.flipHorizontally,
-      initialSudokuField.columnSwap(0,1),
-      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW,
-      initialSudokuField.rotateCCW,
-      initialSudokuField.rotateCW.rotateCW,
-      initialSudokuField.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.flipVertically.transpose,
-      initialSudokuField.flipVertically.rotateCW,
-      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
-      initialSudokuField.rotateCW.rotateCW.transpose
-    ).map(_.toRowUpdates)).flatten.iterator
+  private val rowUpdatesSeq = LazyList
+    .continually(
+      Vector(
+        initialSudokuField,
+        initialSudokuField.flipVertically,
+        initialSudokuField.flipHorizontally,
+        initialSudokuField.flipHorizontally.flipVertically,
+        initialSudokuField.flipVertically.flipHorizontally,
+        initialSudokuField.columnSwap(0, 1),
+        initialSudokuField.rowSwap(4, 5).rowSwap(0, 2),
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW,
+        initialSudokuField.rotateCCW,
+        initialSudokuField.rotateCW.rotateCW,
+        initialSudokuField.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.flipVertically.transpose,
+        initialSudokuField.flipVertically.rotateCW,
+        initialSudokuField.columnSwap(4, 5).columnSwap(0, 2).rowSwap(3, 4),
+        initialSudokuField.rotateCW.rotateCW.transpose
+      ).map(_.toRowUpdates)
+    )
+    .flatten
+    .iterator
 
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
-  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+  timers.startTimerAtFixedRate(SendNewSudoku,
+                               problemSendInterval
+  ) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessage {
-    case SendNewSudoku =>
-      context.log.debug("sending new sudoku problem")
-      val nextRowUpdates = rowUpdatesSeq.next
-      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
-      Behaviors.same
-    case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
-      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
-      Behaviors.same
-  }
+  def sending(): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SendNewSudoku =>
+        context.log.debug("sending new sudoku problem")
+        val nextRowUpdates = rowUpdatesSeq.next
+        sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
+        Behaviors.same
+      case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
+        context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+        Behaviors.same
+    }
 }
-

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProgressTracker {
 
@@ -13,33 +13,47 @@ object SudokuProgressTracker {
   final case class Result(sudoku: Sudoku) extends Response
 
   def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+            sudokuSolver: ActorRef[Response]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
-      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver)
+        .trackProgress(updatesInFlight = 0)
     }
 }
 
-class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-                            context: ActorContext[SudokuProgressTracker.Command],
-                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+class SudokuProgressTracker private (
+  rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+  context: ActorContext[SudokuProgressTracker.Command],
+  sudokuSolver: ActorRef[SudokuProgressTracker.Response]
+) {
 
   import SudokuProgressTracker._
 
-   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
-    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
-      rowDetailProcessors.foreach { case (_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self) }
-      collectEndState()
-    case NewUpdatesInFlight(updateCount) =>
-      trackProgress(updatesInFlight + updateCount)
-    case msg: SudokuDetailState =>
-      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-      Behaviors.same
-  }
+  def trackProgress(updatesInFlight: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+        rowDetailProcessors.foreach {
+          case (_, processor) =>
+            processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self)
+        }
+        collectEndState()
+      case NewUpdatesInFlight(updateCount) =>
+        trackProgress(updatesInFlight + updateCount)
+      case msg: SudokuDetailState =>
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+        Behaviors.same
+    }
 
-  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+  def collectEndState(remainingRows: Int = 9,
+                      endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]
+  ): Behavior[Command] =
     Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
-        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        sudokuSolver ! Result(
+          (detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map {
+            case SudokuDetailState(_, state) => state
+          }
+        )
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
@@ -48,4 +62,3 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
         Behaviors.same
     }
 }
-

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 
 import scala.concurrent.duration._
 
@@ -13,40 +13,53 @@ object SudokuSolver {
   // SudokuSolver Protocol
   sealed trait Command
   final case class InitialRowUpdates(rowUpdates: Vector[SudokuDetailProcessor.RowUpdate],
-                                     replyTo: ActorRef[SudokuSolver.Response]) extends Command
+                                     replyTo: ActorRef[SudokuSolver.Response]
+  ) extends Command
   // Wrapped responses
-  private final case class SudokuDetailProcessorResponseWrapped(response: SudokuDetailProcessor.Response) extends Command
-  private final case class SudokuProgressTrackerResponseWrapped(response: SudokuProgressTracker.Response) extends Command
+  private final case class SudokuDetailProcessorResponseWrapped(
+    response: SudokuDetailProcessor.Response
+  ) extends Command
+  private final case class SudokuProgressTrackerResponseWrapped(
+    response: SudokuProgressTracker.Response
+  ) extends Command
   // My Responses
   sealed trait Response
   final case class SudokuSolution(sudoku: Sudoku) extends Response
 
   import SudokuDetailProcessor.UpdateSender
 
-  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[Command]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+  def genDetailProcessors[A <: SudokoDetailType: UpdateSender](
+    context: ActorContext[Command]
+  ): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
     import scala.language.implicitConversions
-    cellIndexesVector.map {
-      index =>
+    cellIndexesVector
+      .map { index =>
         val detailProcessorName = implicitly[UpdateSender[A]].processorName(index)
         val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
         (index, detailProcessor)
-    }.to(Map) // In Scala 2.13 this can be .to(Map)
+      }
+      .to(Map)
   }
 
   def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
-    Behaviors.supervise[Command] {
-      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
-        Behaviors.setup { context =>
-          new SudokuSolver(context, buffer).idle()
+    Behaviors
+      .supervise[Command] {
+        Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) {
+          buffer =>
+            Behaviors.setup { context =>
+              new SudokuSolver(context, buffer).idle()
+            }
         }
       }
-    }.onFailure[Exception](
-      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
-    )
+      .onFailure[Exception](
+        SupervisorStrategy
+          .restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+      )
 }
 
 class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
-                            buffer: StashBuffer[SudokuSolver.Command]) {
+                            buffer: StashBuffer[SudokuSolver.Command]
+) {
   import CellMappings._
   import SudokuSolver._
 
@@ -55,98 +68,103 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   val progressTrackerResponseMapper: ActorRef[SudokuProgressTracker.Response] =
     context.messageAdapter(response => SudokuProgressTrackerResponseWrapped(response))
 
-  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val rowDetailProcessors = genDetailProcessors[Row](context)
   private val columnDetailProcessors = genDetailProcessors[Column](context)
-  private val blockDetailProcessors  = genDetailProcessors[Block](context)
-  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+  private val blockDetailProcessors = genDetailProcessors[Block](context)
+  private val allDetailProcessors =
+    List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
 
   private val progressTracker =
-    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper),
+                  "sudoku-progress-tracker"
+    )
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessage {
+  def idle(): Behavior[Command] =
+    Behaviors.receiveMessage {
 
-    case InitialRowUpdates(rowUpdates, sender) =>
-      rowUpdates.foreach {
-        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
-          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
-      }
-      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
-      processRequest(Some(sender), System.currentTimeMillis())
-    case unexpectedMsg =>
-      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-      Behaviors.same
-
-  }
-
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
-    case SudokuDetailProcessorResponseWrapped(response) => response match {
-      case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
-        updates.foreach {
-          case (rowCellNr, newCellContent) =>
-
-            val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
-            val columnUpdate = Vector(columnCellNr -> newCellContent)
-            columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
-
-            val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
-            val blockUpdate = Vector(blockCellNr -> newCellContent)
-            blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+      case InitialRowUpdates(rowUpdates, sender) =>
+        rowUpdates.foreach {
+          case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+            rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+        processRequest(Some(sender), System.currentTimeMillis())
+      case unexpectedMsg =>
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
-      case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
-        updates.foreach {
-          case (colCellNr, newCellContent) =>
 
-            val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
-            val rowUpdate = Vector(rowCellNr -> newCellContent)
-            rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+    }
 
-            val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
-            val blockUpdate = Vector(blockCellNr -> newCellContent)
-            blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SudokuDetailProcessorResponseWrapped(response) =>
+        response match {
+          case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
+            updates.foreach {
+              case (rowCellNr, newCellContent) =>
+                val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
+                val columnUpdate = Vector(columnCellNr -> newCellContent)
+                columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+
+                val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
+                val blockUpdate = Vector(blockCellNr -> newCellContent)
+                blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
+            updates.foreach {
+              case (colCellNr, newCellContent) =>
+                val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
+                val rowUpdate = Vector(rowCellNr -> newCellContent)
+                rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+                val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
+                val blockUpdate = Vector(blockCellNr -> newCellContent)
+                blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
+            updates.foreach {
+              case (blockCellNr, newCellContent) =>
+                val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
+                val rowUpdate = Vector(rowCellNr -> newCellContent)
+                rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+                val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
+                val columnUpdate = Vector(columnCellNr -> newCellContent)
+                columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case unchanged @ SudokuDetailProcessor.SudokuDetailUnchanged =>
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+            Behaviors.same
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
-        Behaviors.same
-      case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
-        updates.foreach {
-          case (blockCellNr, newCellContent) =>
-
-            val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
-            val rowUpdate = Vector(rowCellNr -> newCellContent)
-            rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
-
-            val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
-            val columnUpdate = Vector(columnCellNr -> newCellContent)
-            columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+      case SudokuProgressTrackerResponseWrapped(result) =>
+        result match {
+          case SudokuProgressTracker.Result(sudoku) =>
+            context.log.info(
+              s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds"
+            )
+            requestor.get ! SudokuSolution(sudoku)
+            resetAllDetailProcessors()
+            buffer.unstashAll(idle())
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+      case msg: InitialRowUpdates if buffer.isFull =>
+        context.log.info(s"DROPPING REQUEST")
         Behaviors.same
-      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+      case msg: InitialRowUpdates =>
+        buffer.stash(msg)
         Behaviors.same
     }
-    case SudokuProgressTrackerResponseWrapped(result) => result match {
-      case SudokuProgressTracker.Result(sudoku) =>
-        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
-        requestor.get ! SudokuSolution(sudoku)
-        resetAllDetailProcessors()
-        buffer.unstashAll(idle())
-    }
-    case msg: InitialRowUpdates if buffer.isFull =>
-      context.log.info(s"DROPPING REQUEST")
-      Behaviors.same
-    case msg: InitialRowUpdates =>
-      buffer.stash(msg)
-      Behaviors.same
-  }
 
-  private def resetAllDetailProcessors(): Unit = {
+  private def resetAllDetailProcessors(): Unit =
     for {
       processors <- allDetailProcessors
       (_, processor) <- processors
     } processor ! SudokuDetailProcessor.ResetSudokuDetailState
-  }
 
   // Added on purpose to illustrate code rewriting capabilities of dotc
   // for deprecated language features

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS => Millis }
 
 object SudokuSolverSettings {
 

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/package.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/package.scala
@@ -16,13 +16,15 @@ package object sudoku {
 
   import SudokuDetailProcessor.RowUpdate
 
-  implicit class RowUpdatesToSudokuField(val update: Vector[SudokuDetailProcessor.RowUpdate]) extends AnyVal {
+  implicit class RowUpdatesToSudokuField(val update: Vector[SudokuDetailProcessor.RowUpdate])
+      extends AnyVal {
     import scala.language.implicitConversions
     def toSudokuField: SudokuField = {
       val rows =
         update
-          .map { case SudokuDetailProcessor.RowUpdate(id, cellUpdates) => (id, cellUpdates)}
-          .to(Map).withDefaultValue(cellUpdatesEmpty)
+          .map { case SudokuDetailProcessor.RowUpdate(id, cellUpdates) => (id, cellUpdates) }
+          .to(Map)
+          .withDefaultValue(cellUpdatesEmpty)
       val sudoku = for {
         (row, cellUpdates) <- Vector.range(0, 9).map(row => (row, rows(row)))
         x = cellUpdates.to(Map).withDefaultValue(Set(0))
@@ -43,23 +45,21 @@ package object sudoku {
 
     def flipHorizontally: SudokuField = sudokuField.rotateCW.flipVertically.rotateCCW
 
-    def rowSwap(row1: Int, row2: Int): SudokuField = {
+    def rowSwap(row1: Int, row2: Int): SudokuField =
       SudokuField(
         sudokuField.sudoku.zipWithIndex.map {
-        case (_, `row1`) => sudokuField.sudoku(row2)
-        case (_, `row2`) => sudokuField.sudoku(row1)
-        case (row, _) => row
+          case (_, `row1`) => sudokuField.sudoku(row2)
+          case (_, `row2`) => sudokuField.sudoku(row1)
+          case (row, _) => row
         }
       )
-    }
 
-    def columnSwap(col1: Int, col2: Int): SudokuField = {
+    def columnSwap(col1: Int, col2: Int): SudokuField =
       sudokuField.rotateCW.rowSwap(col1, col2).rotateCCW
-    }
 
     def randomSwapAround: SudokuField = {
       import scala.language.implicitConversions
-      val possibleCellValues = Vector(1,2,3,4,5,6,7,8,9)
+      val possibleCellValues = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9)
       // Generate a random swapping of cell values. A value 0 is used as a marker for a cell
       // with an unknown value (i.e. it can still hold all values 0 through 9). As such
       // a cell with value 0 should remain 0 which is why we add an entry to the generated
@@ -71,15 +71,15 @@ package object sudoku {
       })
     }
 
-    def toRowUpdates: Vector[RowUpdate] = {
-      sudokuField
-        .sudoku
+    def toRowUpdates: Vector[RowUpdate] =
+      sudokuField.sudoku
         .map(_.zipWithIndex)
         .map(row => row.filterNot(_._1 == Set(0)))
-        .zipWithIndex.filter(_._1.nonEmpty)
-        .map { case (c, i) =>
-          RowUpdate(i, c.map(_.swap))
+        .zipWithIndex
+        .filter(_._1.nonEmpty)
+        .map {
+          case (c, i) =>
+            RowUpdate(i, c.map(_.swap))
         }
-    }
   }
 }

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -22,26 +22,29 @@ package org.lunatechlabs.dotty
 
 import akka.NotUsed
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
-import akka.actor.typed.scaladsl.{Behaviors, Routers}
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
-import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import akka.actor.typed.{ ActorSystem, Behavior, Terminated }
+import org.lunatechlabs.dotty.sudoku.{ SudokuProblemSender, SudokuSolver, SudokuSolverSettings }
 
-import scala.Console.{GREEN, RESET}
+import scala.Console.{ GREEN, RESET }
 import scala.io.StdIn
 
 object Main {
-  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
-    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
-    // Start a SodukuSolver
-    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
-    // Start a Sudoku problem sender
-    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+  def apply(): Behavior[NotUsed] =
+    Behaviors.setup { context =>
+      val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+      // Start a SodukuSolver
+      val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+      // Start a Sudoku problem sender
+      context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings),
+                    "sudoku-problem-sender"
+      )
 
-    Behaviors.receiveSignal {
-      case (_, Terminated(_)) =>
-        Behaviors.stopped
+      Behaviors.receiveSignal {
+        case (_, Terminated(_)) =>
+          Behaviors.stopped
+      }
     }
-  }
 }
 
 object SudokuSolverMain {

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -15,8 +15,8 @@ object CellMappings {
     rowToBlockCoordinates(cellNr, columnNr)
 
   def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+    ((blockNr / 3) * 3 + cellNr / 3, (blockNr % 3) * 3 + cellNr % 3)
 
   def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+    ((blockNr % 3) * 3 + cellNr % 3, (blockNr / 3) * 3 + cellNr / 3)
 }

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -3,15 +3,16 @@ package org.lunatechlabs.dotty.sudoku
 object ReductionRules {
 
   def reductionRuleOne(reductionSet: ReductionSet): ReductionSet = {
-    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
-    val completeInputCellGroups = inputCellsGrouped filter {
+    val inputCellsGrouped = reductionSet.filter(_.size <= 7).groupBy(identity)
+    val completeInputCellGroups = inputCellsGrouped.filter {
       case (set, setOccurrences) => set.size == setOccurrences.length
     }
     val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
     completeAndIsolatedValueSets.foldLeft(reductionSet) {
-      case (cells, caivSet) => cells.map {
-        cell => if (cell != caivSet) cell &~ caivSet else cell
-      }
+      case (cells, caivSet) =>
+        cells.map { cell =>
+          if (cell != caivSet) cell &~ caivSet else cell
+        }
     }
   }
 
@@ -24,9 +25,10 @@ object ReductionRules {
     }
 
     val cellIndexesToValues =
-      CELLPossibleValues.zip(valueOccurrences)
-        .groupBy { case (value, occurrence) => occurrence}
-        .filter  { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
+      CELLPossibleValues
+        .zip(valueOccurrences)
+        .groupBy { case (value, occurrence) => occurrence }
+        .filter { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
 
     val cellIndexListToReducedValue = cellIndexesToValues.map {
       case (index, seq) => (index, (seq.map { case (value, _) => value }).toSet)
@@ -34,7 +36,7 @@ object ReductionRules {
 
     val cellIndexToReducedValue = cellIndexListToReducedValue.flatMap {
       case (cellIndexList, reducedValue) =>
-        cellIndexList.map ( cellIndex => cellIndex -> reducedValue )
+        cellIndexList.map(cellIndex => cellIndex -> reducedValue)
     }
 
     reductionSet.zipWithIndex.foldRight(Vector.empty[CellContent]) {

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 import org.lunatechlabs.dotty.sudoku.SudokuDetailProcessor.UpdateSender
 
 object SudokuDetailProcessor {
@@ -10,7 +10,8 @@ object SudokuDetailProcessor {
   sealed trait Command
   case object ResetSudokuDetailState extends Command
   final case class Update(cellUpdates: CellUpdates, replyTo: ActorRef[Response]) extends Command
-  final case class GetSudokuDetailState(replyTo: ActorRef[SudokuProgressTracker.Command]) extends Command
+  final case class GetSudokuDetailState(replyTo: ActorRef[SudokuProgressTracker.Command])
+      extends Command
 
   // My responses
   sealed trait Response
@@ -21,94 +22,93 @@ object SudokuDetailProcessor {
 
   val InitialDetailState: ReductionSet = cellIndexesVector.map(_ => initialCell)
 
-  def apply[DetailType <: SudokoDetailType](id: Int,
-                                            state: ReductionSet = InitialDetailState)
-                                           (implicit updateSender: UpdateSender[DetailType]): Behavior[Command] = {
+  def apply[DetailType <: SudokoDetailType](id: Int, state: ReductionSet = InitialDetailState)(
+    implicit updateSender: UpdateSender[DetailType]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
       (new SudokuDetailProcessor[DetailType](context)).operational(id, state, fullyReduced = false)
     }
-  }
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit
-
     def processorName(id: Int): String
   }
 
   implicit val rowUpdateSender: UpdateSender[Row] = new UpdateSender[Row] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit = {
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! RowUpdate(id, cellUpdates)
-    }
-    override def processorName(id: Int): String = s"row-processor-$id"
+    def processorName(id: Int): String = s"row-processor-$id"
   }
 
   implicit val columnUpdateSender: UpdateSender[Column] = new UpdateSender[Column] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"col-processor-$id"
+    def processorName(id: Int): String = s"col-processor-$id"
   }
 
   implicit val blockUpdateSender: UpdateSender[Block] = new UpdateSender[Block] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! BlockUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"blk-processor-$id"
+    def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 
-class SudokuDetailProcessor[DetailType <: SudokoDetailType : UpdateSender] private (context: ActorContext[SudokuDetailProcessor.Command]) {
+class SudokuDetailProcessor[DetailType <: SudokoDetailType: UpdateSender] private (
+  context: ActorContext[SudokuDetailProcessor.Command]
+) {
 
-  import ReductionRules.{reductionRuleOne, reductionRuleTwo}
+  import ReductionRules.{ reductionRuleOne, reductionRuleTwo }
   import SudokuDetailProcessor._
 
   def operational(id: Int, state: ReductionSet, fullyReduced: Boolean): Behavior[Command] =
     Behaviors.receiveMessage {
-    case Update(cellUpdates, replyTo) if ! fullyReduced =>
-      val previousState = state
-      val updatedState = mergeState(state, cellUpdates)
-      if (updatedState == previousState && cellUpdates != cellUpdatesEmpty) {
-        replyTo ! SudokuDetailUnchanged
-        Behaviors.same
-      } else {
-        val transformedUpdatedState = reductionRuleTwo(reductionRuleOne(updatedState))
-        if (transformedUpdatedState == state) {
+      case Update(cellUpdates, replyTo) if !fullyReduced =>
+        val previousState = state
+        val updatedState = mergeState(state, cellUpdates)
+        if (updatedState == previousState && cellUpdates != cellUpdatesEmpty) {
           replyTo ! SudokuDetailUnchanged
           Behaviors.same
-        } else {
-          val updateSender = implicitly[UpdateSender[DetailType]]
-          updateSender.sendUpdate(id, stateChanges(state, transformedUpdatedState))(replyTo)
-          operational(id, transformedUpdatedState, isFullyReduced(transformedUpdatedState))
         }
-      }
+        else {
+          val transformedUpdatedState = reductionRuleTwo(reductionRuleOne(updatedState))
+          if (transformedUpdatedState == state) {
+            replyTo ! SudokuDetailUnchanged
+            Behaviors.same
+          }
+          else {
+            val updateSender = implicitly[UpdateSender[DetailType]]
+            updateSender.sendUpdate(id, stateChanges(state, transformedUpdatedState))(replyTo)
+            operational(id, transformedUpdatedState, isFullyReduced(transformedUpdatedState))
+          }
+        }
 
-    case Update(cellUpdates, replyTo) =>
-      replyTo ! SudokuDetailUnchanged
-      Behaviors.same
+      case Update(cellUpdates, replyTo) =>
+        replyTo ! SudokuDetailUnchanged
+        Behaviors.same
 
-    case GetSudokuDetailState(replyTo) =>
-      replyTo ! SudokuProgressTracker.SudokuDetailState(id, state)
-      Behaviors.same
+      case GetSudokuDetailState(replyTo) =>
+        replyTo ! SudokuProgressTracker.SudokuDetailState(id, state)
+        Behaviors.same
 
-    case ResetSudokuDetailState =>
-      operational(id, InitialDetailState, fullyReduced = false)
+      case ResetSudokuDetailState =>
+        operational(id, InitialDetailState, fullyReduced = false)
 
-  }
+    }
 
-  private def mergeState(state: ReductionSet, cellUpdates: CellUpdates): ReductionSet = {
-      cellUpdates.foldLeft(state) {
+  private def mergeState(state: ReductionSet, cellUpdates: CellUpdates): ReductionSet =
+    cellUpdates.foldLeft(state) {
       case (stateTally, (index, updatedCellContent)) =>
         stateTally.updated(index, stateTally(index) & updatedCellContent)
     }
-  }
 
-  private def stateChanges(state: ReductionSet, updatedState: ReductionSet): CellUpdates = {
-    (state zip updatedState).zipWithIndex.foldRight(cellUpdatesEmpty) {
+  private def stateChanges(state: ReductionSet, updatedState: ReductionSet): CellUpdates =
+    state.zip(updatedState).zipWithIndex.foldRight(cellUpdatesEmpty) {
       case (((previousCellContent, updatedCellContent), index), cellUpdates)
-        if updatedCellContent != previousCellContent =>
+          if updatedCellContent != previousCellContent =>
         (index, updatedCellContent) +: cellUpdates
 
       case (_, cellUpdates) => cellUpdates
     }
-  }
 
   private def isFullyReduced(state: ReductionSet): Boolean = {
     val allValuesInState = state.flatten

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -2,8 +2,8 @@ package org.lunatechlabs.dotty.sudoku
 
 import java.io.File
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProblemSender {
 
@@ -13,11 +13,13 @@ object SudokuProblemSender {
   private final case class SolutionWrapper(result: SudokuSolver.Response) extends Command
 
   private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
-    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
+    SudokuIO
+      .readSudokuFromFile(new File("sudokus/001.sudoku"))
       .map { case (rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update) }
 
   def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
-            sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
+            sudokuSolverSettings: SudokuSolverSettings
+  ): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
         new SudokuProblemSender(sudokuSolver, context, timers, sudokuSolverSettings).sending()
@@ -28,7 +30,8 @@ object SudokuProblemSender {
 class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
                                    context: ActorContext[SudokuProblemSender.Command],
                                    timers: TimerScheduler[SudokuProblemSender.Command],
-                                   sudokuSolverSettings: SudokuSolverSettings) {
+                                   sudokuSolverSettings: SudokuSolverSettings
+) {
   import SudokuProblemSender._
 
   private val solutionWrapper: ActorRef[SudokuSolver.Response] =
@@ -36,45 +39,51 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
 
   private val initialSudokuField = rowUpdates.toSudokuField
 
-  private val rowUpdatesSeq = LazyList.continually(
-    Vector(
-      initialSudokuField,
-      initialSudokuField.flipVertically,
-      initialSudokuField.flipHorizontally,
-      initialSudokuField.flipHorizontally.flipVertically,
-      initialSudokuField.flipVertically.flipHorizontally,
-      initialSudokuField.columnSwap(0,1),
-      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW,
-      initialSudokuField.rotateCCW,
-      initialSudokuField.rotateCW.rotateCW,
-      initialSudokuField.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.flipVertically.transpose,
-      initialSudokuField.flipVertically.rotateCW,
-      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
-      initialSudokuField.rotateCW.rotateCW.transpose
-    ).map(_.toRowUpdates)).flatten.iterator
+  private val rowUpdatesSeq = LazyList
+    .continually(
+      Vector(
+        initialSudokuField,
+        initialSudokuField.flipVertically,
+        initialSudokuField.flipHorizontally,
+        initialSudokuField.flipHorizontally.flipVertically,
+        initialSudokuField.flipVertically.flipHorizontally,
+        initialSudokuField.columnSwap(0, 1),
+        initialSudokuField.rowSwap(4, 5).rowSwap(0, 2),
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW,
+        initialSudokuField.rotateCCW,
+        initialSudokuField.rotateCW.rotateCW,
+        initialSudokuField.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.flipVertically.transpose,
+        initialSudokuField.flipVertically.rotateCW,
+        initialSudokuField.columnSwap(4, 5).columnSwap(0, 2).rowSwap(3, 4),
+        initialSudokuField.rotateCW.rotateCW.transpose
+      ).map(_.toRowUpdates)
+    )
+    .flatten
+    .iterator
 
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
-  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+  timers.startTimerAtFixedRate(SendNewSudoku,
+                               problemSendInterval
+  ) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessage {
-    case SendNewSudoku =>
-      context.log.debug("sending new sudoku problem")
-      val nextRowUpdates = rowUpdatesSeq.next
-      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
-      Behaviors.same
-    case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
-      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
-      Behaviors.same
-  }
+  def sending(): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SendNewSudoku =>
+        context.log.debug("sending new sudoku problem")
+        val nextRowUpdates = rowUpdatesSeq.next
+        sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
+        Behaviors.same
+      case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
+        context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+        Behaviors.same
+    }
 }
-

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProgressTracker {
 
@@ -13,33 +13,47 @@ object SudokuProgressTracker {
   final case class Result(sudoku: Sudoku) extends Response
 
   def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+            sudokuSolver: ActorRef[Response]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
-      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver)
+        .trackProgress(updatesInFlight = 0)
     }
 }
 
-class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-                            context: ActorContext[SudokuProgressTracker.Command],
-                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+class SudokuProgressTracker private (
+  rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+  context: ActorContext[SudokuProgressTracker.Command],
+  sudokuSolver: ActorRef[SudokuProgressTracker.Response]
+) {
 
   import SudokuProgressTracker._
 
-   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
-    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
-      rowDetailProcessors.foreach { case (_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self) }
-      collectEndState()
-    case NewUpdatesInFlight(updateCount) =>
-      trackProgress(updatesInFlight + updateCount)
-    case msg: SudokuDetailState =>
-      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-      Behaviors.same
-  }
+  def trackProgress(updatesInFlight: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+        rowDetailProcessors.foreach {
+          case (_, processor) =>
+            processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self)
+        }
+        collectEndState()
+      case NewUpdatesInFlight(updateCount) =>
+        trackProgress(updatesInFlight + updateCount)
+      case msg: SudokuDetailState =>
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+        Behaviors.same
+    }
 
-  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+  def collectEndState(remainingRows: Int = 9,
+                      endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]
+  ): Behavior[Command] =
     Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
-        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        sudokuSolver ! Result(
+          (detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map {
+            case SudokuDetailState(_, state) => state
+          }
+        )
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
@@ -48,4 +62,3 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
         Behaviors.same
     }
 }
-

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 
 import scala.concurrent.duration._
 
@@ -13,40 +13,53 @@ object SudokuSolver {
   // SudokuSolver Protocol
   sealed trait Command
   final case class InitialRowUpdates(rowUpdates: Vector[SudokuDetailProcessor.RowUpdate],
-                                     replyTo: ActorRef[SudokuSolver.Response]) extends Command
+                                     replyTo: ActorRef[SudokuSolver.Response]
+  ) extends Command
   // Wrapped responses
-  private final case class SudokuDetailProcessorResponseWrapped(response: SudokuDetailProcessor.Response) extends Command
-  private final case class SudokuProgressTrackerResponseWrapped(response: SudokuProgressTracker.Response) extends Command
+  private final case class SudokuDetailProcessorResponseWrapped(
+    response: SudokuDetailProcessor.Response
+  ) extends Command
+  private final case class SudokuProgressTrackerResponseWrapped(
+    response: SudokuProgressTracker.Response
+  ) extends Command
   // My Responses
   sealed trait Response
   final case class SudokuSolution(sudoku: Sudoku) extends Response
 
   import SudokuDetailProcessor.UpdateSender
 
-  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[Command]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+  def genDetailProcessors[A <: SudokoDetailType: UpdateSender](
+    context: ActorContext[Command]
+  ): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
     import scala.language.implicitConversions
-    cellIndexesVector.map {
-      index =>
+    cellIndexesVector
+      .map { index =>
         val detailProcessorName = implicitly[UpdateSender[A]].processorName(index)
         val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
         (index, detailProcessor)
-    }.to(Map) // In Scala 2.13 this can be .to(Map)
+      }
+      .to(Map)
   }
 
   def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
-    Behaviors.supervise[Command] {
-      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
-        Behaviors.setup { context =>
-          new SudokuSolver(context, buffer).idle()
+    Behaviors
+      .supervise[Command] {
+        Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) {
+          buffer =>
+            Behaviors.setup { context =>
+              new SudokuSolver(context, buffer).idle()
+            }
         }
       }
-    }.onFailure[Exception](
-      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
-    )
+      .onFailure[Exception](
+        SupervisorStrategy
+          .restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+      )
 }
 
 class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
-                            buffer: StashBuffer[SudokuSolver.Command]) {
+                            buffer: StashBuffer[SudokuSolver.Command]
+) {
   import CellMappings._
   import SudokuSolver._
 
@@ -55,96 +68,101 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   val progressTrackerResponseMapper: ActorRef[SudokuProgressTracker.Response] =
     context.messageAdapter(response => SudokuProgressTrackerResponseWrapped(response))
 
-  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val rowDetailProcessors = genDetailProcessors[Row](context)
   private val columnDetailProcessors = genDetailProcessors[Column](context)
-  private val blockDetailProcessors  = genDetailProcessors[Block](context)
-  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+  private val blockDetailProcessors = genDetailProcessors[Block](context)
+  private val allDetailProcessors =
+    List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
 
   private val progressTracker =
-    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper),
+                  "sudoku-progress-tracker"
+    )
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessage {
+  def idle(): Behavior[Command] =
+    Behaviors.receiveMessage {
 
-    case InitialRowUpdates(rowUpdates, sender) =>
-      rowUpdates.foreach {
-        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
-          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
-      }
-      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
-      processRequest(Some(sender), System.currentTimeMillis())
-    case unexpectedMsg =>
-      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-      Behaviors.same
-
-  }
-
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
-    case SudokuDetailProcessorResponseWrapped(response) => response match {
-      case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
-        updates.foreach {
-          case (rowCellNr, newCellContent) =>
-
-            val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
-            val columnUpdate = Vector(columnCellNr -> newCellContent)
-            columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
-
-            val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
-            val blockUpdate = Vector(blockCellNr -> newCellContent)
-            blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+      case InitialRowUpdates(rowUpdates, sender) =>
+        rowUpdates.foreach {
+          case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+            rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+        processRequest(Some(sender), System.currentTimeMillis())
+      case unexpectedMsg =>
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
-      case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
-        updates.foreach {
-          case (colCellNr, newCellContent) =>
 
-            val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
-            val rowUpdate = Vector(rowCellNr -> newCellContent)
-            rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+    }
 
-            val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
-            val blockUpdate = Vector(blockCellNr -> newCellContent)
-            blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SudokuDetailProcessorResponseWrapped(response) =>
+        response match {
+          case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
+            updates.foreach {
+              case (rowCellNr, newCellContent) =>
+                val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
+                val columnUpdate = Vector(columnCellNr -> newCellContent)
+                columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+
+                val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
+                val blockUpdate = Vector(blockCellNr -> newCellContent)
+                blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
+            updates.foreach {
+              case (colCellNr, newCellContent) =>
+                val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
+                val rowUpdate = Vector(rowCellNr -> newCellContent)
+                rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+                val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
+                val blockUpdate = Vector(blockCellNr -> newCellContent)
+                blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
+            updates.foreach {
+              case (blockCellNr, newCellContent) =>
+                val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
+                val rowUpdate = Vector(rowCellNr -> newCellContent)
+                rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+                val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
+                val columnUpdate = Vector(columnCellNr -> newCellContent)
+                columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case unchanged @ SudokuDetailProcessor.SudokuDetailUnchanged =>
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+            Behaviors.same
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
-        Behaviors.same
-      case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
-        updates.foreach {
-          case (blockCellNr, newCellContent) =>
-
-            val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
-            val rowUpdate = Vector(rowCellNr -> newCellContent)
-            rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
-
-            val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
-            val columnUpdate = Vector(columnCellNr -> newCellContent)
-            columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+      case SudokuProgressTrackerResponseWrapped(result) =>
+        result match {
+          case SudokuProgressTracker.Result(sudoku) =>
+            context.log.info(
+              s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds"
+            )
+            requestor.get ! SudokuSolution(sudoku)
+            resetAllDetailProcessors()
+            buffer.unstashAll(idle())
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+      case msg: InitialRowUpdates if buffer.isFull =>
+        context.log.info(s"DROPPING REQUEST")
         Behaviors.same
-      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+      case msg: InitialRowUpdates =>
+        buffer.stash(msg)
         Behaviors.same
     }
-    case SudokuProgressTrackerResponseWrapped(result) => result match {
-      case SudokuProgressTracker.Result(sudoku) =>
-        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
-        requestor.get ! SudokuSolution(sudoku)
-        resetAllDetailProcessors()
-        buffer.unstashAll(idle())
-    }
-    case msg: InitialRowUpdates if buffer.isFull =>
-      context.log.info(s"DROPPING REQUEST")
-      Behaviors.same
-    case msg: InitialRowUpdates =>
-      buffer.stash(msg)
-      Behaviors.same
-  }
 
-  private def resetAllDetailProcessors(): Unit = {
+  private def resetAllDetailProcessors(): Unit =
     for {
       processors <- allDetailProcessors
       (_, processor) <- processors
     } processor ! SudokuDetailProcessor.ResetSudokuDetailState
-  }
 }

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS => Millis }
 
 object SudokuSolverSettings {
 

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/package.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/package.scala
@@ -16,13 +16,15 @@ package object sudoku {
 
   import SudokuDetailProcessor.RowUpdate
 
-  implicit class RowUpdatesToSudokuField(val update: Vector[SudokuDetailProcessor.RowUpdate]) extends AnyVal {
+  implicit class RowUpdatesToSudokuField(val update: Vector[SudokuDetailProcessor.RowUpdate])
+      extends AnyVal {
     import scala.language.implicitConversions
     def toSudokuField: SudokuField = {
       val rows =
         update
-          .map { case SudokuDetailProcessor.RowUpdate(id, cellUpdates) => (id, cellUpdates)}
-          .to(Map).withDefaultValue(cellUpdatesEmpty)
+          .map { case SudokuDetailProcessor.RowUpdate(id, cellUpdates) => (id, cellUpdates) }
+          .to(Map)
+          .withDefaultValue(cellUpdatesEmpty)
       val sudoku = for {
         (row, cellUpdates) <- Vector.range(0, 9).map(row => (row, rows(row)))
         x = cellUpdates.to(Map).withDefaultValue(Set(0))
@@ -43,23 +45,21 @@ package object sudoku {
 
     def flipHorizontally: SudokuField = sudokuField.rotateCW.flipVertically.rotateCCW
 
-    def rowSwap(row1: Int, row2: Int): SudokuField = {
+    def rowSwap(row1: Int, row2: Int): SudokuField =
       SudokuField(
         sudokuField.sudoku.zipWithIndex.map {
-        case (_, `row1`) => sudokuField.sudoku(row2)
-        case (_, `row2`) => sudokuField.sudoku(row1)
-        case (row, _) => row
+          case (_, `row1`) => sudokuField.sudoku(row2)
+          case (_, `row2`) => sudokuField.sudoku(row1)
+          case (row, _) => row
         }
       )
-    }
 
-    def columnSwap(col1: Int, col2: Int): SudokuField = {
+    def columnSwap(col1: Int, col2: Int): SudokuField =
       sudokuField.rotateCW.rowSwap(col1, col2).rotateCCW
-    }
 
     def randomSwapAround: SudokuField = {
       import scala.language.implicitConversions
-      val possibleCellValues = Vector(1,2,3,4,5,6,7,8,9)
+      val possibleCellValues = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9)
       // Generate a random swapping of cell values. A value 0 is used as a marker for a cell
       // with an unknown value (i.e. it can still hold all values 0 through 9). As such
       // a cell with value 0 should remain 0 which is why we add an entry to the generated
@@ -71,15 +71,15 @@ package object sudoku {
       })
     }
 
-    def toRowUpdates: Vector[RowUpdate] = {
-      sudokuField
-        .sudoku
+    def toRowUpdates: Vector[RowUpdate] =
+      sudokuField.sudoku
         .map(_.zipWithIndex)
         .map(row => row.filterNot(_._1 == Set(0)))
-        .zipWithIndex.filter(_._1.nonEmpty)
-        .map { case (c, i) =>
-          RowUpdate(i, c.map(_.swap))
+        .zipWithIndex
+        .filter(_._1.nonEmpty)
+        .map {
+          case (c, i) =>
+            RowUpdate(i, c.map(_.swap))
         }
-    }
   }
 }

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -22,25 +22,28 @@ package org.lunatechlabs.dotty
 
 import akka.NotUsed
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
-import akka.actor.typed.scaladsl.{Behaviors, Routers}
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
-import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import akka.actor.typed.{ ActorSystem, Behavior, Terminated }
+import org.lunatechlabs.dotty.sudoku.{ SudokuProblemSender, SudokuSolver, SudokuSolverSettings }
 import scala.io.StdIn
-import Console.{GREEN, RESET}
+import scala.Console.{ GREEN, RESET }
 
 object Main {
-  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
-    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
-    // Start a SodukuSolver
-    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
-    // Start a Sudoku problem sender
-    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+  def apply(): Behavior[NotUsed] =
+    Behaviors.setup { context =>
+      val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+      // Start a SodukuSolver
+      val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+      // Start a Sudoku problem sender
+      context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings),
+                    "sudoku-problem-sender"
+      )
 
-    Behaviors.receiveSignal {
-      case (_, Terminated(_)) =>
-        Behaviors.stopped
+      Behaviors.receiveSignal {
+        case (_, Terminated(_)) =>
+          Behaviors.stopped
+      }
     }
-  }
 }
 
 object SudokuSolverMain {

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -15,8 +15,8 @@ object CellMappings {
     rowToBlockCoordinates(cellNr, columnNr)
 
   def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+    ((blockNr / 3) * 3 + cellNr / 3, (blockNr % 3) * 3 + cellNr % 3)
 
   def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+    ((blockNr % 3) * 3 + cellNr % 3, (blockNr / 3) * 3 + cellNr / 3)
 }

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -3,15 +3,16 @@ package org.lunatechlabs.dotty.sudoku
 object ReductionRules {
 
   def reductionRuleOne(reductionSet: ReductionSet): ReductionSet = {
-    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
-    val completeInputCellGroups = inputCellsGrouped filter {
+    val inputCellsGrouped = reductionSet.filter(_.size <= 7).groupBy(identity)
+    val completeInputCellGroups = inputCellsGrouped.filter {
       case (set, setOccurrences) => set.size == setOccurrences.length
     }
     val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
     completeAndIsolatedValueSets.foldLeft(reductionSet) {
-      case (cells, caivSet) => cells.map {
-        cell => if (cell != caivSet) cell &~ caivSet else cell
-      }
+      case (cells, caivSet) =>
+        cells.map { cell =>
+          if (cell != caivSet) cell &~ caivSet else cell
+        }
     }
   }
 
@@ -24,9 +25,10 @@ object ReductionRules {
     }
 
     val cellIndexesToValues =
-      CELLPossibleValues.zip(valueOccurrences)
-        .groupBy { case (value, occurrence) => occurrence}
-        .filter  { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
+      CELLPossibleValues
+        .zip(valueOccurrences)
+        .groupBy { case (value, occurrence) => occurrence }
+        .filter { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
 
     val cellIndexListToReducedValue = cellIndexesToValues.map {
       case (index, seq) => (index, (seq.map { case (value, _) => value }).toSet)
@@ -34,7 +36,7 @@ object ReductionRules {
 
     val cellIndexToReducedValue = cellIndexListToReducedValue.flatMap {
       case (cellIndexList, reducedValue) =>
-        cellIndexList.map ( cellIndex => cellIndex -> reducedValue )
+        cellIndexList.map(cellIndex => cellIndex -> reducedValue)
     }
 
     reductionSet.zipWithIndex.foldRight(Vector.empty[CellContent]) {

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -31,27 +31,26 @@ object SudokuDetailProcessor {
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit
-
     def processorName(id: Int): String
   }
 
   implicit val rowUpdateSender: UpdateSender[Row] = new UpdateSender[Row] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit = {
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit = {
       sender ! RowUpdate(id, cellUpdates)
     }
-    override def processorName(id: Int): String = s"row-processor-$id"
+    def processorName(id: Int): String = s"row-processor-$id"
   }
 
   implicit val columnUpdateSender: UpdateSender[Column] = new UpdateSender[Column] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"col-processor-$id"
+    def processorName(id: Int): String = s"col-processor-$id"
   }
 
   implicit val blockUpdateSender: UpdateSender[Block] = new UpdateSender[Block] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! BlockUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"blk-processor-$id"
+    def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -2,8 +2,8 @@ package org.lunatechlabs.dotty.sudoku
 
 import java.io.File
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProblemSender {
 
@@ -13,11 +13,13 @@ object SudokuProblemSender {
   private final case class SolutionWrapper(result: SudokuSolver.Response) extends Command
 
   private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
-    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
+    SudokuIO
+      .readSudokuFromFile(new File("sudokus/001.sudoku"))
       .map { case (rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update) }
 
   def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
-            sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
+            sudokuSolverSettings: SudokuSolverSettings
+  ): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
         new SudokuProblemSender(sudokuSolver, context, timers, sudokuSolverSettings).sending()
@@ -28,7 +30,8 @@ object SudokuProblemSender {
 class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
                                    context: ActorContext[SudokuProblemSender.Command],
                                    timers: TimerScheduler[SudokuProblemSender.Command],
-                                   sudokuSolverSettings: SudokuSolverSettings) {
+                                   sudokuSolverSettings: SudokuSolverSettings
+) {
   import SudokuProblemSender._
 
   private val solutionWrapper: ActorRef[SudokuSolver.Response] =
@@ -36,45 +39,51 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
 
   private val initialSudokuField = rowUpdates.toSudokuField
 
-  private val rowUpdatesSeq = LazyList.continually(
-    Vector(
-      initialSudokuField,
-      initialSudokuField.flipVertically,
-      initialSudokuField.flipHorizontally,
-      initialSudokuField.flipHorizontally.flipVertically,
-      initialSudokuField.flipVertically.flipHorizontally,
-      initialSudokuField.columnSwap(0,1),
-      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW,
-      initialSudokuField.rotateCCW,
-      initialSudokuField.rotateCW.rotateCW,
-      initialSudokuField.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.flipVertically.transpose,
-      initialSudokuField.flipVertically.rotateCW,
-      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
-      initialSudokuField.rotateCW.rotateCW.transpose
-    ).map(_.toRowUpdates)).flatten.iterator
+  private val rowUpdatesSeq = LazyList
+    .continually(
+      Vector(
+        initialSudokuField,
+        initialSudokuField.flipVertically,
+        initialSudokuField.flipHorizontally,
+        initialSudokuField.flipHorizontally.flipVertically,
+        initialSudokuField.flipVertically.flipHorizontally,
+        initialSudokuField.columnSwap(0, 1),
+        initialSudokuField.rowSwap(4, 5).rowSwap(0, 2),
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW,
+        initialSudokuField.rotateCCW,
+        initialSudokuField.rotateCW.rotateCW,
+        initialSudokuField.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.flipVertically.transpose,
+        initialSudokuField.flipVertically.rotateCW,
+        initialSudokuField.columnSwap(4, 5).columnSwap(0, 2).rowSwap(3, 4),
+        initialSudokuField.rotateCW.rotateCW.transpose
+      ).map(_.toRowUpdates)
+    )
+    .flatten
+    .iterator
 
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
-  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+  timers.startTimerAtFixedRate(SendNewSudoku,
+                               problemSendInterval
+  ) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessage {
-    case SendNewSudoku =>
-      context.log.debug("sending new sudoku problem")
-      val nextRowUpdates = rowUpdatesSeq.next
-      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
-      Behaviors.same
-    case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
-      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
-      Behaviors.same
-  }
+  def sending(): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SendNewSudoku =>
+        context.log.debug("sending new sudoku problem")
+        val nextRowUpdates = rowUpdatesSeq.next
+        sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
+        Behaviors.same
+      case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
+        context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+        Behaviors.same
+    }
 }
-

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProgressTracker {
 
@@ -13,33 +13,47 @@ object SudokuProgressTracker {
   final case class Result(sudoku: Sudoku) extends Response
 
   def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+            sudokuSolver: ActorRef[Response]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
-      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver)
+        .trackProgress(updatesInFlight = 0)
     }
 }
 
-class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-                            context: ActorContext[SudokuProgressTracker.Command],
-                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+class SudokuProgressTracker private (
+  rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+  context: ActorContext[SudokuProgressTracker.Command],
+  sudokuSolver: ActorRef[SudokuProgressTracker.Response]
+) {
 
   import SudokuProgressTracker._
 
-   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
-    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
-      rowDetailProcessors.foreach { case (_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self) }
-      collectEndState()
-    case NewUpdatesInFlight(updateCount) =>
-      trackProgress(updatesInFlight + updateCount)
-    case msg: SudokuDetailState =>
-      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-      Behaviors.same
-  }
+  def trackProgress(updatesInFlight: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+        rowDetailProcessors.foreach {
+          case (_, processor) =>
+            processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self)
+        }
+        collectEndState()
+      case NewUpdatesInFlight(updateCount) =>
+        trackProgress(updatesInFlight + updateCount)
+      case msg: SudokuDetailState =>
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+        Behaviors.same
+    }
 
-  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+  def collectEndState(remainingRows: Int = 9,
+                      endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]
+  ): Behavior[Command] =
     Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
-        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        sudokuSolver ! Result(
+          (detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map {
+            case SudokuDetailState(_, state) => state
+          }
+        )
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
@@ -48,4 +62,3 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
         Behaviors.same
     }
 }
-

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 
 import scala.concurrent.duration._
 
@@ -13,40 +13,53 @@ object SudokuSolver {
   // SudokuSolver Protocol
   sealed trait Command
   final case class InitialRowUpdates(rowUpdates: Vector[SudokuDetailProcessor.RowUpdate],
-                                     replyTo: ActorRef[SudokuSolver.Response]) extends Command
+                                     replyTo: ActorRef[SudokuSolver.Response]
+  ) extends Command
   // Wrapped responses
-  private final case class SudokuDetailProcessorResponseWrapped(response: SudokuDetailProcessor.Response) extends Command
-  private final case class SudokuProgressTrackerResponseWrapped(response: SudokuProgressTracker.Response) extends Command
+  private final case class SudokuDetailProcessorResponseWrapped(
+    response: SudokuDetailProcessor.Response
+  ) extends Command
+  private final case class SudokuProgressTrackerResponseWrapped(
+    response: SudokuProgressTracker.Response
+  ) extends Command
   // My Responses
   sealed trait Response
   final case class SudokuSolution(sudoku: Sudoku) extends Response
 
   import SudokuDetailProcessor.UpdateSender
 
-  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[Command]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+  def genDetailProcessors[A <: SudokoDetailType: UpdateSender](
+    context: ActorContext[Command]
+  ): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
     import scala.language.implicitConversions
-    cellIndexesVector.map {
-      index =>
+    cellIndexesVector
+      .map { index =>
         val detailProcessorName = implicitly[UpdateSender[A]].processorName(index)
         val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
         (index, detailProcessor)
-    }.to(Map) // In Scala 2.13 this can be .to(Map)
+      }
+      .to(Map)
   }
 
   def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
-    Behaviors.supervise[Command] {
-      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
-        Behaviors.setup { context =>
-          new SudokuSolver(context, buffer).idle()
+    Behaviors
+      .supervise[Command] {
+        Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) {
+          buffer =>
+            Behaviors.setup { context =>
+              new SudokuSolver(context, buffer).idle()
+            }
         }
       }
-    }.onFailure[Exception](
-      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
-    )
+      .onFailure[Exception](
+        SupervisorStrategy
+          .restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+      )
 }
 
 class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
-                            buffer: StashBuffer[SudokuSolver.Command]) {
+                            buffer: StashBuffer[SudokuSolver.Command]
+) {
   import CellMappings._
   import SudokuSolver._
 
@@ -55,96 +68,101 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   val progressTrackerResponseMapper: ActorRef[SudokuProgressTracker.Response] =
     context.messageAdapter(response => SudokuProgressTrackerResponseWrapped(response))
 
-  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val rowDetailProcessors = genDetailProcessors[Row](context)
   private val columnDetailProcessors = genDetailProcessors[Column](context)
-  private val blockDetailProcessors  = genDetailProcessors[Block](context)
-  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+  private val blockDetailProcessors = genDetailProcessors[Block](context)
+  private val allDetailProcessors =
+    List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
 
   private val progressTracker =
-    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper),
+                  "sudoku-progress-tracker"
+    )
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessage {
+  def idle(): Behavior[Command] =
+    Behaviors.receiveMessage {
 
-    case InitialRowUpdates(rowUpdates, sender) =>
-      rowUpdates.foreach {
-        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
-          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
-      }
-      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
-      processRequest(Some(sender), System.currentTimeMillis())
-    case unexpectedMsg =>
-      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-      Behaviors.same
-
-  }
-
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
-    case SudokuDetailProcessorResponseWrapped(response) => response match {
-      case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
-        updates.foreach {
-          case (rowCellNr, newCellContent) =>
-
-            val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
-            val columnUpdate = Vector(columnCellNr -> newCellContent)
-            columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
-
-            val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
-            val blockUpdate = Vector(blockCellNr -> newCellContent)
-            blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+      case InitialRowUpdates(rowUpdates, sender) =>
+        rowUpdates.foreach {
+          case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+            rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+        processRequest(Some(sender), System.currentTimeMillis())
+      case unexpectedMsg =>
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
-      case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
-        updates.foreach {
-          case (colCellNr, newCellContent) =>
 
-            val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
-            val rowUpdate = Vector(rowCellNr -> newCellContent)
-            rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+    }
 
-            val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
-            val blockUpdate = Vector(blockCellNr -> newCellContent)
-            blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SudokuDetailProcessorResponseWrapped(response) =>
+        response match {
+          case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
+            updates.foreach {
+              case (rowCellNr, newCellContent) =>
+                val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
+                val columnUpdate = Vector(columnCellNr -> newCellContent)
+                columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+
+                val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
+                val blockUpdate = Vector(blockCellNr -> newCellContent)
+                blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
+            updates.foreach {
+              case (colCellNr, newCellContent) =>
+                val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
+                val rowUpdate = Vector(rowCellNr -> newCellContent)
+                rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+                val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
+                val blockUpdate = Vector(blockCellNr -> newCellContent)
+                blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
+            updates.foreach {
+              case (blockCellNr, newCellContent) =>
+                val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
+                val rowUpdate = Vector(rowCellNr -> newCellContent)
+                rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+                val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
+                val columnUpdate = Vector(columnCellNr -> newCellContent)
+                columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case unchanged @ SudokuDetailProcessor.SudokuDetailUnchanged =>
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+            Behaviors.same
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
-        Behaviors.same
-      case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
-        updates.foreach {
-          case (blockCellNr, newCellContent) =>
-
-            val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
-            val rowUpdate = Vector(rowCellNr -> newCellContent)
-            rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
-
-            val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
-            val columnUpdate = Vector(columnCellNr -> newCellContent)
-            columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+      case SudokuProgressTrackerResponseWrapped(result) =>
+        result match {
+          case SudokuProgressTracker.Result(sudoku) =>
+            context.log.info(
+              s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds"
+            )
+            requestor.get ! SudokuSolution(sudoku)
+            resetAllDetailProcessors()
+            buffer.unstashAll(idle())
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+      case msg: InitialRowUpdates if buffer.isFull =>
+        context.log.info(s"DROPPING REQUEST")
         Behaviors.same
-      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+      case msg: InitialRowUpdates =>
+        buffer.stash(msg)
         Behaviors.same
     }
-    case SudokuProgressTrackerResponseWrapped(result) => result match {
-      case SudokuProgressTracker.Result(sudoku) =>
-        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
-        requestor.get ! SudokuSolution(sudoku)
-        resetAllDetailProcessors()
-        buffer.unstashAll(idle())
-    }
-    case msg: InitialRowUpdates if buffer.isFull =>
-      context.log.info(s"DROPPING REQUEST")
-      Behaviors.same
-    case msg: InitialRowUpdates =>
-      buffer.stash(msg)
-      Behaviors.same
-  }
 
-  private def resetAllDetailProcessors(): Unit = {
+  private def resetAllDetailProcessors(): Unit =
     for {
       processors <- allDetailProcessors
       (_, processor) <- processors
     } processor ! SudokuDetailProcessor.ResetSudokuDetailState
-  }
 }

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS => Millis }
 
 object SudokuSolverSettings {
 

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -22,25 +22,28 @@ package org.lunatechlabs.dotty
 
 import akka.NotUsed
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
-import akka.actor.typed.scaladsl.{Behaviors, Routers}
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
-import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import akka.actor.typed.{ ActorSystem, Behavior, Terminated }
+import org.lunatechlabs.dotty.sudoku.{ SudokuProblemSender, SudokuSolver, SudokuSolverSettings }
 import scala.io.StdIn
-import Console.{GREEN, RESET}
+import scala.Console.{ GREEN, RESET }
 
 object Main {
-  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
-    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
-    // Start a SodukuSolver
-    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
-    // Start a Sudoku problem sender
-    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+  def apply(): Behavior[NotUsed] =
+    Behaviors.setup { context =>
+      val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+      // Start a SodukuSolver
+      val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+      // Start a Sudoku problem sender
+      context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings),
+                    "sudoku-problem-sender"
+      )
 
-    Behaviors.receiveSignal {
-      case (_, Terminated(_)) =>
-        Behaviors.stopped
+      Behaviors.receiveSignal {
+        case (_, Terminated(_)) =>
+          Behaviors.stopped
+      }
     }
-  }
 }
 
 object SudokuSolverMain {

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -15,8 +15,8 @@ object CellMappings {
     rowToBlockCoordinates(cellNr, columnNr)
 
   def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+    ((blockNr / 3) * 3 + cellNr / 3, (blockNr % 3) * 3 + cellNr % 3)
 
   def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+    ((blockNr % 3) * 3 + cellNr % 3, (blockNr / 3) * 3 + cellNr / 3)
 }

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -3,14 +3,14 @@ package org.lunatechlabs.dotty.sudoku
 object ReductionRules {
 
   def reductionRuleOne(reductionSet: ReductionSet): ReductionSet = {
-    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
-    val completeInputCellGroups = inputCellsGrouped filter { (set, setOccurrences) =>
+    val inputCellsGrouped = reductionSet.filter(_.size <= 7).groupBy(identity)
+    val completeInputCellGroups = inputCellsGrouped.filter { (set, setOccurrences) => 
       set.size == setOccurrences.length
     }
     val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
     completeAndIsolatedValueSets.foldLeft(reductionSet) { (cells, caivSet) =>
-      cells.map {
-        cell => if (cell != caivSet) cell &~ caivSet else cell
+      cells.map { cell =>
+        if (cell != caivSet) cell &~ caivSet else cell
       }
     }
   }
@@ -24,16 +24,17 @@ object ReductionRules {
     }
 
     val cellIndexesToValues =
-      CELLPossibleValues.zip(valueOccurrences)
-        .groupBy ((value, occurrence) => occurrence)
-        .filter  ((loc, occ) => loc.length == occ.length && loc.length <= 6 )
+      CELLPossibleValues
+        .zip(valueOccurrences)
+        .groupBy ((value, occurrence) => occurrence )
+        .filter { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
 
     val cellIndexListToReducedValue = cellIndexesToValues.map { (index, seq) =>
       (index, (seq.map ((value, _) => value )).toSet)
     }
 
-    val cellIndexToReducedValue = cellIndexListToReducedValue flatMap { (cellIndexList, reducedValue) =>
-      cellIndexList map { cellIndex => cellIndex -> reducedValue }
+    val cellIndexToReducedValue = cellIndexListToReducedValue.flatMap { (cellIndexList, reducedValue) =>
+      cellIndexList.map(cellIndex => cellIndex -> reducedValue)
     }
 
     reductionSet.zipWithIndex.foldRight(Vector.empty[CellContent]) {

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -31,27 +31,26 @@ object SudokuDetailProcessor {
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit
-
     def processorName(id: Int): String
   }
 
   implicit val rowUpdateSender: UpdateSender[Row] = new UpdateSender[Row] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit = {
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit = {
       sender ! RowUpdate(id, cellUpdates)
     }
-    override def processorName(id: Int): String = s"row-processor-$id"
+    def processorName(id: Int): String = s"row-processor-$id"
   }
 
   implicit val columnUpdateSender: UpdateSender[Column] = new UpdateSender[Column] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"col-processor-$id"
+    def processorName(id: Int): String = s"col-processor-$id"
   }
 
   implicit val blockUpdateSender: UpdateSender[Block] = new UpdateSender[Block] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! BlockUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"blk-processor-$id"
+    def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -2,8 +2,8 @@ package org.lunatechlabs.dotty.sudoku
 
 import java.io.File
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProblemSender {
 
@@ -13,11 +13,13 @@ object SudokuProblemSender {
   private final case class SolutionWrapper(result: SudokuSolver.Response) extends Command
 
   private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
-    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
-      .map((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
+    SudokuIO
+      .readSudokuFromFile(new File("sudokus/001.sudoku"))
+      .map ((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
 
   def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
-            sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
+            sudokuSolverSettings: SudokuSolverSettings
+  ): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
         new SudokuProblemSender(sudokuSolver, context, timers, sudokuSolverSettings).sending()
@@ -28,7 +30,8 @@ object SudokuProblemSender {
 class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
                                    context: ActorContext[SudokuProblemSender.Command],
                                    timers: TimerScheduler[SudokuProblemSender.Command],
-                                   sudokuSolverSettings: SudokuSolverSettings) {
+                                   sudokuSolverSettings: SudokuSolverSettings
+) {
   import SudokuProblemSender._
 
   private val solutionWrapper: ActorRef[SudokuSolver.Response] =
@@ -36,45 +39,51 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
 
   private val initialSudokuField = rowUpdates.toSudokuField
 
-  private val rowUpdatesSeq = LazyList.continually(
-    Vector(
-      initialSudokuField,
-      initialSudokuField.flipVertically,
-      initialSudokuField.flipHorizontally,
-      initialSudokuField.flipHorizontally.flipVertically,
-      initialSudokuField.flipVertically.flipHorizontally,
-      initialSudokuField.columnSwap(0,1),
-      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW,
-      initialSudokuField.rotateCCW,
-      initialSudokuField.rotateCW.rotateCW,
-      initialSudokuField.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.flipVertically.transpose,
-      initialSudokuField.flipVertically.rotateCW,
-      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
-      initialSudokuField.rotateCW.rotateCW.transpose
-    ).map(_.toRowUpdates)).flatten.iterator
+  private val rowUpdatesSeq = LazyList
+    .continually(
+      Vector(
+        initialSudokuField,
+        initialSudokuField.flipVertically,
+        initialSudokuField.flipHorizontally,
+        initialSudokuField.flipHorizontally.flipVertically,
+        initialSudokuField.flipVertically.flipHorizontally,
+        initialSudokuField.columnSwap(0, 1),
+        initialSudokuField.rowSwap(4, 5).rowSwap(0, 2),
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW,
+        initialSudokuField.rotateCCW,
+        initialSudokuField.rotateCW.rotateCW,
+        initialSudokuField.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.flipVertically.transpose,
+        initialSudokuField.flipVertically.rotateCW,
+        initialSudokuField.columnSwap(4, 5).columnSwap(0, 2).rowSwap(3, 4),
+        initialSudokuField.rotateCW.rotateCW.transpose
+      ).map(_.toRowUpdates)
+    )
+    .flatten
+    .iterator
 
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
-  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+  timers.startTimerAtFixedRate(SendNewSudoku,
+                               problemSendInterval
+  ) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessage {
-    case SendNewSudoku =>
-      context.log.debug("sending new sudoku problem")
-      val nextRowUpdates = rowUpdatesSeq.next
-      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
-      Behaviors.same
-    case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
-      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
-      Behaviors.same
-  }
+  def sending(): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SendNewSudoku =>
+        context.log.debug("sending new sudoku problem")
+        val nextRowUpdates = rowUpdatesSeq.next
+        sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
+        Behaviors.same
+      case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
+        context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+        Behaviors.same
+    }
 }
-

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProgressTracker {
 
@@ -13,33 +13,46 @@ object SudokuProgressTracker {
   final case class Result(sudoku: Sudoku) extends Response
 
   def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+            sudokuSolver: ActorRef[Response]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
-      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver)
+        .trackProgress(updatesInFlight = 0)
     }
 }
 
-class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-                            context: ActorContext[SudokuProgressTracker.Command],
-                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+class SudokuProgressTracker private (
+  rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+  context: ActorContext[SudokuProgressTracker.Command],
+  sudokuSolver: ActorRef[SudokuProgressTracker.Response]
+) {
 
   import SudokuProgressTracker._
 
-   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
-    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
-      rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
-      collectEndState()
-    case NewUpdatesInFlight(updateCount) =>
-      trackProgress(updatesInFlight + updateCount)
-    case msg: SudokuDetailState =>
-      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-      Behaviors.same
-  }
+  def trackProgress(updatesInFlight: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+        rowDetailProcessors.foreach ((_, processor) =>
+            processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self)
+        )
+        collectEndState()
+      case NewUpdatesInFlight(updateCount) =>
+        trackProgress(updatesInFlight + updateCount)
+      case msg: SudokuDetailState =>
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+        Behaviors.same
+    }
 
-  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+  def collectEndState(remainingRows: Int = 9,
+                      endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]
+  ): Behavior[Command] =
     Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
-        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        sudokuSolver ! Result(
+          (detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map {
+            case SudokuDetailState(_, state) => state
+          }
+        )
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
@@ -48,4 +61,3 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
         Behaviors.same
     }
 }
-

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 
 import scala.concurrent.duration._
 
@@ -13,40 +13,53 @@ object SudokuSolver {
   // SudokuSolver Protocol
   sealed trait Command
   final case class InitialRowUpdates(rowUpdates: Vector[SudokuDetailProcessor.RowUpdate],
-                                     replyTo: ActorRef[SudokuSolver.Response]) extends Command
+                                     replyTo: ActorRef[SudokuSolver.Response]
+  ) extends Command
   // Wrapped responses
-  private final case class SudokuDetailProcessorResponseWrapped(response: SudokuDetailProcessor.Response) extends Command
-  private final case class SudokuProgressTrackerResponseWrapped(response: SudokuProgressTracker.Response) extends Command
+  private final case class SudokuDetailProcessorResponseWrapped(
+    response: SudokuDetailProcessor.Response
+  ) extends Command
+  private final case class SudokuProgressTrackerResponseWrapped(
+    response: SudokuProgressTracker.Response
+  ) extends Command
   // My Responses
   sealed trait Response
   final case class SudokuSolution(sudoku: Sudoku) extends Response
 
   import SudokuDetailProcessor.UpdateSender
 
-  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[Command]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+  def genDetailProcessors[A <: SudokoDetailType: UpdateSender](
+    context: ActorContext[Command]
+  ): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
     import scala.language.implicitConversions
-    cellIndexesVector.map {
-      index =>
+    cellIndexesVector
+      .map { index =>
         val detailProcessorName = implicitly[UpdateSender[A]].processorName(index)
         val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
         (index, detailProcessor)
-    }.to(Map) // In Scala 2.13 this can be .to(Map)
+      }
+      .to(Map)
   }
 
   def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
-    Behaviors.supervise[Command] {
-      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
-        Behaviors.setup { context =>
-          new SudokuSolver(context, buffer).idle()
+    Behaviors
+      .supervise[Command] {
+        Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) {
+          buffer =>
+            Behaviors.setup { context =>
+              new SudokuSolver(context, buffer).idle()
+            }
         }
       }
-    }.onFailure[Exception](
-      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
-    )
+      .onFailure[Exception](
+        SupervisorStrategy
+          .restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+      )
 }
 
 class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
-                            buffer: StashBuffer[SudokuSolver.Command]) {
+                            buffer: StashBuffer[SudokuSolver.Command]
+) {
   import CellMappings._
   import SudokuSolver._
 
@@ -55,93 +68,98 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   val progressTrackerResponseMapper: ActorRef[SudokuProgressTracker.Response] =
     context.messageAdapter(response => SudokuProgressTrackerResponseWrapped(response))
 
-  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val rowDetailProcessors = genDetailProcessors[Row](context)
   private val columnDetailProcessors = genDetailProcessors[Column](context)
-  private val blockDetailProcessors  = genDetailProcessors[Block](context)
-  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+  private val blockDetailProcessors = genDetailProcessors[Block](context)
+  private val allDetailProcessors =
+    List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
 
   private val progressTracker =
-    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper),
+                  "sudoku-progress-tracker"
+    )
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessage {
+  def idle(): Behavior[Command] =
+    Behaviors.receiveMessage {
 
-    case InitialRowUpdates(rowUpdates, sender) =>
-      rowUpdates.foreach {
-        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
-          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
-      }
-      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
-      processRequest(Some(sender), System.currentTimeMillis())
-    case unexpectedMsg =>
-      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-      Behaviors.same
-
-  }
-
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
-    case SudokuDetailProcessorResponseWrapped(response) => response match {
-      case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
-        updates.foreach { (rowCellNr, newCellContent) =>
-
-          val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
-          val columnUpdate = Vector(columnCellNr -> newCellContent)
-          columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
-
-          val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
-          val blockUpdate = Vector(blockCellNr -> newCellContent)
-          blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+      case InitialRowUpdates(rowUpdates, sender) =>
+        rowUpdates.foreach {
+          case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+            rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+        processRequest(Some(sender), System.currentTimeMillis())
+      case unexpectedMsg =>
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
-      case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
-        updates.foreach { (colCellNr, newCellContent) =>
 
-          val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
-          val rowUpdate = Vector(rowCellNr -> newCellContent)
-          rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+    }
 
-          val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
-          val blockUpdate = Vector(blockCellNr -> newCellContent)
-          blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SudokuDetailProcessorResponseWrapped(response) =>
+        response match {
+          case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
+            updates.foreach { (rowCellNr, newCellContent) =>
+              val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
+              val columnUpdate = Vector(columnCellNr -> newCellContent)
+              columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+
+              val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
+              val blockUpdate = Vector(blockCellNr -> newCellContent)
+              blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
+            updates.foreach { (colCellNr, newCellContent) =>
+              val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
+              val rowUpdate = Vector(rowCellNr -> newCellContent)
+              rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+              val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
+              val blockUpdate = Vector(blockCellNr -> newCellContent)
+              blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
+            updates.foreach { (blockCellNr, newCellContent) =>
+              val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
+              val rowUpdate = Vector(rowCellNr -> newCellContent)
+              rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+              val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
+              val columnUpdate = Vector(columnCellNr -> newCellContent)
+              columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case unchanged @ SudokuDetailProcessor.SudokuDetailUnchanged =>
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+            Behaviors.same
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
-        Behaviors.same
-      case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
-        updates.foreach { (blockCellNr, newCellContent) =>
-
-          val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
-          val rowUpdate = Vector(rowCellNr -> newCellContent)
-          rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
-
-          val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
-          val columnUpdate = Vector(columnCellNr -> newCellContent)
-          columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+      case SudokuProgressTrackerResponseWrapped(result) =>
+        result match {
+          case SudokuProgressTracker.Result(sudoku) =>
+            context.log.info(
+              s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds"
+            )
+            requestor.get ! SudokuSolution(sudoku)
+            resetAllDetailProcessors()
+            buffer.unstashAll(idle())
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+      case msg: InitialRowUpdates if buffer.isFull =>
+        context.log.info(s"DROPPING REQUEST")
         Behaviors.same
-      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+      case msg: InitialRowUpdates =>
+        buffer.stash(msg)
         Behaviors.same
     }
-    case SudokuProgressTrackerResponseWrapped(result) => result match {
-      case SudokuProgressTracker.Result(sudoku) =>
-        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
-        requestor.get ! SudokuSolution(sudoku)
-        resetAllDetailProcessors()
-        buffer.unstashAll(idle())
-    }
-    case msg: InitialRowUpdates if buffer.isFull =>
-      context.log.info(s"DROPPING REQUEST")
-      Behaviors.same
-    case msg: InitialRowUpdates =>
-      buffer.stash(msg)
-      Behaviors.same
-  }
 
-  private def resetAllDetailProcessors(): Unit = {
+  private def resetAllDetailProcessors(): Unit =
     for {
       processors <- allDetailProcessors
       (_, processor) <- processors
     } processor ! SudokuDetailProcessor.ResetSudokuDetailState
-  }
 }

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS => Millis }
 
 object SudokuSolverSettings {
 

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -22,25 +22,28 @@ package org.lunatechlabs.dotty
 
 import akka.NotUsed
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
-import akka.actor.typed.scaladsl.{Behaviors, Routers}
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
-import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import akka.actor.typed.{ ActorSystem, Behavior, Terminated }
+import org.lunatechlabs.dotty.sudoku.{ SudokuProblemSender, SudokuSolver, SudokuSolverSettings }
 import scala.io.StdIn
-import Console.{GREEN, RESET}
+import scala.Console.{ GREEN, RESET }
 
 object Main {
-  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
-    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
-    // Start a SodukuSolver
-    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
-    // Start a Sudoku problem sender
-    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+  def apply(): Behavior[NotUsed] =
+    Behaviors.setup { context =>
+      val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+      // Start a SodukuSolver
+      val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+      // Start a Sudoku problem sender
+      context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings),
+                    "sudoku-problem-sender"
+      )
 
-    Behaviors.receiveSignal {
-      case (_, Terminated(_)) =>
-        Behaviors.stopped
+      Behaviors.receiveSignal {
+        case (_, Terminated(_)) =>
+          Behaviors.stopped
+      }
     }
-  }
 }
 
 object SudokuSolverMain {

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -15,8 +15,8 @@ object CellMappings {
     rowToBlockCoordinates(cellNr, columnNr)
 
   def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+    ((blockNr / 3) * 3 + cellNr / 3, (blockNr % 3) * 3 + cellNr % 3)
 
   def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+    ((blockNr % 3) * 3 + cellNr % 3, (blockNr / 3) * 3 + cellNr / 3)
 }

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -4,14 +4,14 @@ package org.lunatechlabs.dotty.sudoku
 extension reductionRules on (reductionSet: ReductionSet) {
 
   def applyReductionRuleOne: ReductionSet = {
-    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
+    val inputCellsGrouped = reductionSet.filter {_.size <= 7}.groupBy(identity)
     val completeInputCellGroups = inputCellsGrouped filter { (set, setOccurrences) =>
       set.size == setOccurrences.length
     }
     val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
     completeAndIsolatedValueSets.foldLeft(reductionSet) { (cells, caivSet) =>
-      cells.map {
-        cell => if (cell != caivSet) cell &~ caivSet else cell
+      cells.map { cell =>
+        if (cell != caivSet) cell &~ caivSet else cell
       }
     }
   }
@@ -25,16 +25,17 @@ extension reductionRules on (reductionSet: ReductionSet) {
     }
 
     val cellIndexesToValues =
-      CELLPossibleValues.zip(valueOccurrences)
-        .groupBy ((value, occurrence) => occurrence)
-        .filter  ((loc, occ) => loc.length == occ.length && loc.length <= 6 )
+      CELLPossibleValues
+        .zip(valueOccurrences)
+        .groupBy ((value, occurrence) => occurrence )
+        .filter { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
 
     val cellIndexListToReducedValue = cellIndexesToValues.map { (index, seq) =>
       (index, (seq.map ((value, _) => value )).toSet)
     }
 
-    val cellIndexToReducedValue = cellIndexListToReducedValue flatMap { (cellIndexList, reducedValue) => 
-      cellIndexList map { cellIndex => cellIndex -> reducedValue }
+    val cellIndexToReducedValue = cellIndexListToReducedValue.flatMap { (cellIndexList, reducedValue) =>
+      cellIndexList.map(cellIndex => cellIndex -> reducedValue)
     }
 
     reductionSet.zipWithIndex.foldRight(Vector.empty[CellContent]) {

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -31,27 +31,26 @@ object SudokuDetailProcessor {
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit
-
     def processorName(id: Int): String
   }
 
   implicit val rowUpdateSender: UpdateSender[Row] = new UpdateSender[Row] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit = {
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit = {
       sender ! RowUpdate(id, cellUpdates)
     }
-    override def processorName(id: Int): String = s"row-processor-$id"
+    def processorName(id: Int): String = s"row-processor-$id"
   }
 
   implicit val columnUpdateSender: UpdateSender[Column] = new UpdateSender[Column] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"col-processor-$id"
+    def processorName(id: Int): String = s"col-processor-$id"
   }
 
   implicit val blockUpdateSender: UpdateSender[Block] = new UpdateSender[Block] {
-    override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
+    def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef[Response]): Unit =
       sender ! BlockUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"blk-processor-$id"
+    def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -2,8 +2,8 @@ package org.lunatechlabs.dotty.sudoku
 
 import java.io.File
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProblemSender {
 
@@ -13,11 +13,13 @@ object SudokuProblemSender {
   private final case class SolutionWrapper(result: SudokuSolver.Response) extends Command
 
   private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
-    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
-      .map((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
+    SudokuIO
+      .readSudokuFromFile(new File("sudokus/001.sudoku"))
+      .map ((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
 
   def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
-            sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
+            sudokuSolverSettings: SudokuSolverSettings
+  ): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
         new SudokuProblemSender(sudokuSolver, context, timers, sudokuSolverSettings).sending()
@@ -28,7 +30,8 @@ object SudokuProblemSender {
 class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
                                    context: ActorContext[SudokuProblemSender.Command],
                                    timers: TimerScheduler[SudokuProblemSender.Command],
-                                   sudokuSolverSettings: SudokuSolverSettings) {
+                                   sudokuSolverSettings: SudokuSolverSettings
+) {
   import SudokuProblemSender._
 
   private val solutionWrapper: ActorRef[SudokuSolver.Response] =
@@ -36,45 +39,51 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
 
   private val initialSudokuField = rowUpdates.toSudokuField
 
-  private val rowUpdatesSeq = LazyList.continually(
-    Vector(
-      initialSudokuField,
-      initialSudokuField.flipVertically,
-      initialSudokuField.flipHorizontally,
-      initialSudokuField.flipHorizontally.flipVertically,
-      initialSudokuField.flipVertically.flipHorizontally,
-      initialSudokuField.columnSwap(0,1),
-      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW,
-      initialSudokuField.rotateCCW,
-      initialSudokuField.rotateCW.rotateCW,
-      initialSudokuField.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.flipVertically.transpose,
-      initialSudokuField.flipVertically.rotateCW,
-      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
-      initialSudokuField.rotateCW.rotateCW.transpose
-    ).map(_.toRowUpdates)).flatten.iterator
+  private val rowUpdatesSeq = LazyList
+    .continually(
+      Vector(
+        initialSudokuField,
+        initialSudokuField.flipVertically,
+        initialSudokuField.flipHorizontally,
+        initialSudokuField.flipHorizontally.flipVertically,
+        initialSudokuField.flipVertically.flipHorizontally,
+        initialSudokuField.columnSwap(0, 1),
+        initialSudokuField.rowSwap(4, 5).rowSwap(0, 2),
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW,
+        initialSudokuField.rotateCCW,
+        initialSudokuField.rotateCW.rotateCW,
+        initialSudokuField.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.flipVertically.transpose,
+        initialSudokuField.flipVertically.rotateCW,
+        initialSudokuField.columnSwap(4, 5).columnSwap(0, 2).rowSwap(3, 4),
+        initialSudokuField.rotateCW.rotateCW.transpose
+      ).map(_.toRowUpdates)
+    )
+    .flatten
+    .iterator
 
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
-  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+  timers.startTimerAtFixedRate(SendNewSudoku,
+                               problemSendInterval
+  ) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessage {
-    case SendNewSudoku =>
-      context.log.debug("sending new sudoku problem")
-      val nextRowUpdates = rowUpdatesSeq.next
-      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
-      Behaviors.same
-    case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
-      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
-      Behaviors.same
-  }
+  def sending(): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SendNewSudoku =>
+        context.log.debug("sending new sudoku problem")
+        val nextRowUpdates = rowUpdatesSeq.next
+        sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
+        Behaviors.same
+      case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
+        context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+        Behaviors.same
+    }
 }
-

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProgressTracker {
 
@@ -13,33 +13,46 @@ object SudokuProgressTracker {
   final case class Result(sudoku: Sudoku) extends Response
 
   def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+            sudokuSolver: ActorRef[Response]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
-      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver)
+        .trackProgress(updatesInFlight = 0)
     }
 }
 
-class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-                            context: ActorContext[SudokuProgressTracker.Command],
-                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+class SudokuProgressTracker private (
+  rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+  context: ActorContext[SudokuProgressTracker.Command],
+  sudokuSolver: ActorRef[SudokuProgressTracker.Response]
+) {
 
   import SudokuProgressTracker._
 
-   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
-    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
-      rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
-      collectEndState()
-    case NewUpdatesInFlight(updateCount) =>
-      trackProgress(updatesInFlight + updateCount)
-    case msg: SudokuDetailState =>
-      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-      Behaviors.same
-  }
+  def trackProgress(updatesInFlight: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+        rowDetailProcessors.foreach ((_, processor) =>
+            processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self)
+        )
+        collectEndState()
+      case NewUpdatesInFlight(updateCount) =>
+        trackProgress(updatesInFlight + updateCount)
+      case msg: SudokuDetailState =>
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+        Behaviors.same
+    }
 
-  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+  def collectEndState(remainingRows: Int = 9,
+                      endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]
+  ): Behavior[Command] =
     Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
-        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        sudokuSolver ! Result(
+          (detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map {
+            case SudokuDetailState(_, state) => state
+          }
+        )
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
@@ -48,4 +61,3 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
         Behaviors.same
     }
 }
-

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 
 import scala.concurrent.duration._
 
@@ -13,40 +13,53 @@ object SudokuSolver {
   // SudokuSolver Protocol
   sealed trait Command
   final case class InitialRowUpdates(rowUpdates: Vector[SudokuDetailProcessor.RowUpdate],
-                                     replyTo: ActorRef[SudokuSolver.Response]) extends Command
+                                     replyTo: ActorRef[SudokuSolver.Response]
+  ) extends Command
   // Wrapped responses
-  private final case class SudokuDetailProcessorResponseWrapped(response: SudokuDetailProcessor.Response) extends Command
-  private final case class SudokuProgressTrackerResponseWrapped(response: SudokuProgressTracker.Response) extends Command
+  private final case class SudokuDetailProcessorResponseWrapped(
+    response: SudokuDetailProcessor.Response
+  ) extends Command
+  private final case class SudokuProgressTrackerResponseWrapped(
+    response: SudokuProgressTracker.Response
+  ) extends Command
   // My Responses
   sealed trait Response
   final case class SudokuSolution(sudoku: Sudoku) extends Response
 
   import SudokuDetailProcessor.UpdateSender
 
-  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[Command]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+  def genDetailProcessors[A <: SudokoDetailType: UpdateSender](
+    context: ActorContext[Command]
+  ): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
     import scala.language.implicitConversions
-    cellIndexesVector.map {
-      index =>
+    cellIndexesVector
+      .map { index =>
         val detailProcessorName = implicitly[UpdateSender[A]].processorName(index)
         val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
         (index, detailProcessor)
-    }.to(Map) // In Scala 2.13 this can be .to(Map)
+      }
+      .to(Map)
   }
 
   def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
-    Behaviors.supervise[Command] {
-      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
-        Behaviors.setup { context =>
-          new SudokuSolver(context, buffer).idle()
+    Behaviors
+      .supervise[Command] {
+        Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) {
+          buffer =>
+            Behaviors.setup { context =>
+              new SudokuSolver(context, buffer).idle()
+            }
         }
       }
-    }.onFailure[Exception](
-      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
-    )
+      .onFailure[Exception](
+        SupervisorStrategy
+          .restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+      )
 }
 
 class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
-                            buffer: StashBuffer[SudokuSolver.Command]) {
+                            buffer: StashBuffer[SudokuSolver.Command]
+) {
   import CellMappings._
   import SudokuSolver._
 
@@ -55,93 +68,98 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   val progressTrackerResponseMapper: ActorRef[SudokuProgressTracker.Response] =
     context.messageAdapter(response => SudokuProgressTrackerResponseWrapped(response))
 
-  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val rowDetailProcessors = genDetailProcessors[Row](context)
   private val columnDetailProcessors = genDetailProcessors[Column](context)
-  private val blockDetailProcessors  = genDetailProcessors[Block](context)
-  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+  private val blockDetailProcessors = genDetailProcessors[Block](context)
+  private val allDetailProcessors =
+    List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
 
   private val progressTracker =
-    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper),
+                  "sudoku-progress-tracker"
+    )
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessage {
+  def idle(): Behavior[Command] =
+    Behaviors.receiveMessage {
 
-    case InitialRowUpdates(rowUpdates, sender) =>
-      rowUpdates.foreach {
-        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
-          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
-      }
-      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
-      processRequest(Some(sender), System.currentTimeMillis())
-    case unexpectedMsg =>
-      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-      Behaviors.same
-
-  }
-
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
-    case SudokuDetailProcessorResponseWrapped(response) => response match {
-      case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
-        updates.foreach { (rowCellNr, newCellContent) =>
-
-          val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
-          val columnUpdate = Vector(columnCellNr -> newCellContent)
-          columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
-
-          val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
-          val blockUpdate = Vector(blockCellNr -> newCellContent)
-          blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+      case InitialRowUpdates(rowUpdates, sender) =>
+        rowUpdates.foreach {
+          case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+            rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+        processRequest(Some(sender), System.currentTimeMillis())
+      case unexpectedMsg =>
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
-      case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
-        updates.foreach { (colCellNr, newCellContent) =>
 
-          val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
-          val rowUpdate = Vector(rowCellNr -> newCellContent)
-          rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+    }
 
-          val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
-          val blockUpdate = Vector(blockCellNr -> newCellContent)
-          blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SudokuDetailProcessorResponseWrapped(response) =>
+        response match {
+          case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
+            updates.foreach { (rowCellNr, newCellContent) =>
+              val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
+              val columnUpdate = Vector(columnCellNr -> newCellContent)
+              columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+
+              val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
+              val blockUpdate = Vector(blockCellNr -> newCellContent)
+              blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
+            updates.foreach { (colCellNr, newCellContent) =>
+              val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
+              val rowUpdate = Vector(rowCellNr -> newCellContent)
+              rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+              val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
+              val blockUpdate = Vector(blockCellNr -> newCellContent)
+              blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
+            updates.foreach { (blockCellNr, newCellContent) =>
+              val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
+              val rowUpdate = Vector(rowCellNr -> newCellContent)
+              rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+              val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
+              val columnUpdate = Vector(columnCellNr -> newCellContent)
+              columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case unchanged @ SudokuDetailProcessor.SudokuDetailUnchanged =>
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+            Behaviors.same
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
-        Behaviors.same
-      case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
-        updates.foreach { (blockCellNr, newCellContent) =>
-
-          val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
-          val rowUpdate = Vector(rowCellNr -> newCellContent)
-          rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
-
-          val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
-          val columnUpdate = Vector(columnCellNr -> newCellContent)
-          columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+      case SudokuProgressTrackerResponseWrapped(result) =>
+        result match {
+          case SudokuProgressTracker.Result(sudoku) =>
+            context.log.info(
+              s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds"
+            )
+            requestor.get ! SudokuSolution(sudoku)
+            resetAllDetailProcessors()
+            buffer.unstashAll(idle())
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+      case msg: InitialRowUpdates if buffer.isFull =>
+        context.log.info(s"DROPPING REQUEST")
         Behaviors.same
-      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+      case msg: InitialRowUpdates =>
+        buffer.stash(msg)
         Behaviors.same
     }
-    case SudokuProgressTrackerResponseWrapped(result) => result match {
-      case SudokuProgressTracker.Result(sudoku) =>
-        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
-        requestor.get ! SudokuSolution(sudoku)
-        resetAllDetailProcessors()
-        buffer.unstashAll(idle())
-    }
-    case msg: InitialRowUpdates if buffer.isFull =>
-      context.log.info(s"DROPPING REQUEST")
-      Behaviors.same
-    case msg: InitialRowUpdates =>
-      buffer.stash(msg)
-      Behaviors.same
-  }
 
-  private def resetAllDetailProcessors(): Unit = {
+  private def resetAllDetailProcessors(): Unit =
     for {
       processors <- allDetailProcessors
       (_, processor) <- processors
     } processor ! SudokuDetailProcessor.ResetSudokuDetailState
-  }
 }

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS => Millis }
 
 object SudokuSolverSettings {
 

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -22,25 +22,28 @@ package org.lunatechlabs.dotty
 
 import akka.NotUsed
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
-import akka.actor.typed.scaladsl.{Behaviors, Routers}
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
-import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import akka.actor.typed.{ ActorSystem, Behavior, Terminated }
+import org.lunatechlabs.dotty.sudoku.{ SudokuProblemSender, SudokuSolver, SudokuSolverSettings }
 import scala.io.StdIn
-import Console.{GREEN, RESET}
+import scala.Console.{ GREEN, RESET }
 
 object Main {
-  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
-    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
-    // Start a SodukuSolver
-    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
-    // Start a Sudoku problem sender
-    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+  def apply(): Behavior[NotUsed] =
+    Behaviors.setup { context =>
+      val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+      // Start a SodukuSolver
+      val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+      // Start a Sudoku problem sender
+      context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings),
+                    "sudoku-problem-sender"
+      )
 
-    Behaviors.receiveSignal {
-      case (_, Terminated(_)) =>
-        Behaviors.stopped
+      Behaviors.receiveSignal {
+        case (_, Terminated(_)) =>
+          Behaviors.stopped
+      }
     }
-  }
 }
 
 object SudokuSolverMain {

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -15,8 +15,8 @@ object CellMappings {
     rowToBlockCoordinates(cellNr, columnNr)
 
   def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+    ((blockNr / 3) * 3 + cellNr / 3, (blockNr % 3) * 3 + cellNr % 3)
 
   def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+    ((blockNr % 3) * 3 + cellNr % 3, (blockNr / 3) * 3 + cellNr / 3)
 }

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -4,14 +4,14 @@ package org.lunatechlabs.dotty.sudoku
 extension reductionRules on (reductionSet: ReductionSet) {
 
   def applyReductionRuleOne: ReductionSet = {
-    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
+    val inputCellsGrouped = reductionSet.filter {_.size <= 7}.groupBy(identity)
     val completeInputCellGroups = inputCellsGrouped filter { (set, setOccurrences) =>
       set.size == setOccurrences.length
     }
     val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
     completeAndIsolatedValueSets.foldLeft(reductionSet) { (cells, caivSet) =>
-      cells.map {
-        cell => if (cell != caivSet) cell &~ caivSet else cell
+      cells.map { cell =>
+        if (cell != caivSet) cell &~ caivSet else cell
       }
     }
   }
@@ -25,16 +25,17 @@ extension reductionRules on (reductionSet: ReductionSet) {
     }
 
     val cellIndexesToValues =
-      CELLPossibleValues.zip(valueOccurrences)
-        .groupBy ((value, occurrence) => occurrence)
-        .filter  ((loc, occ) => loc.length == occ.length && loc.length <= 6 )
+      CELLPossibleValues
+        .zip(valueOccurrences)
+        .groupBy ((value, occurrence) => occurrence )
+        .filter { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
 
     val cellIndexListToReducedValue = cellIndexesToValues.map { (index, seq) =>
       (index, (seq.map ((value, _) => value )).toSet)
     }
 
-    val cellIndexToReducedValue = cellIndexListToReducedValue flatMap { (cellIndexList, reducedValue) => 
-      cellIndexList map { cellIndex => cellIndex -> reducedValue }
+    val cellIndexToReducedValue = cellIndexListToReducedValue.flatMap { (cellIndexList, reducedValue) =>
+      cellIndexList.map(cellIndex => cellIndex -> reducedValue)
     }
 
     reductionSet.zipWithIndex.foldRight(Vector.empty[CellContent]) {

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -31,7 +31,6 @@ object SudokuDetailProcessor {
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit
-
     def processorName(id: Int): String
   }
 
@@ -39,19 +38,19 @@ object SudokuDetailProcessor {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit = {
       sender ! RowUpdate(id, cellUpdates)
     }
-    override def processorName(id: Int): String = s"row-processor-$id"
+    def processorName(id: Int): String = s"row-processor-$id"
   }
 
   implicit val columnUpdateSender: UpdateSender[Column] = new UpdateSender[Column] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"col-processor-$id"
+    def processorName(id: Int): String = s"col-processor-$id"
   }
 
   implicit val blockUpdateSender: UpdateSender[Block] = new UpdateSender[Block] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
       sender ! BlockUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"blk-processor-$id"
+    def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -2,8 +2,8 @@ package org.lunatechlabs.dotty.sudoku
 
 import java.io.File
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProblemSender {
 
@@ -13,11 +13,13 @@ object SudokuProblemSender {
   private final case class SolutionWrapper(result: SudokuSolver.Response) extends Command
 
   private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
-    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
-      .map((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
+    SudokuIO
+      .readSudokuFromFile(new File("sudokus/001.sudoku"))
+      .map ((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
 
   def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
-            sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
+            sudokuSolverSettings: SudokuSolverSettings
+  ): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
         new SudokuProblemSender(sudokuSolver, context, timers, sudokuSolverSettings).sending()
@@ -28,7 +30,8 @@ object SudokuProblemSender {
 class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
                                    context: ActorContext[SudokuProblemSender.Command],
                                    timers: TimerScheduler[SudokuProblemSender.Command],
-                                   sudokuSolverSettings: SudokuSolverSettings) {
+                                   sudokuSolverSettings: SudokuSolverSettings
+) {
   import SudokuProblemSender._
 
   private val solutionWrapper: ActorRef[SudokuSolver.Response] =
@@ -36,45 +39,51 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
 
   private val initialSudokuField = rowUpdates.toSudokuField
 
-  private val rowUpdatesSeq = LazyList.continually(
-    Vector(
-      initialSudokuField,
-      initialSudokuField.flipVertically,
-      initialSudokuField.flipHorizontally,
-      initialSudokuField.flipHorizontally.flipVertically,
-      initialSudokuField.flipVertically.flipHorizontally,
-      initialSudokuField.columnSwap(0,1),
-      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW,
-      initialSudokuField.rotateCCW,
-      initialSudokuField.rotateCW.rotateCW,
-      initialSudokuField.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.flipVertically.transpose,
-      initialSudokuField.flipVertically.rotateCW,
-      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
-      initialSudokuField.rotateCW.rotateCW.transpose
-    ).map(_.toRowUpdates)).flatten.iterator
+  private val rowUpdatesSeq = LazyList
+    .continually(
+      Vector(
+        initialSudokuField,
+        initialSudokuField.flipVertically,
+        initialSudokuField.flipHorizontally,
+        initialSudokuField.flipHorizontally.flipVertically,
+        initialSudokuField.flipVertically.flipHorizontally,
+        initialSudokuField.columnSwap(0, 1),
+        initialSudokuField.rowSwap(4, 5).rowSwap(0, 2),
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW,
+        initialSudokuField.rotateCCW,
+        initialSudokuField.rotateCW.rotateCW,
+        initialSudokuField.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.flipVertically.transpose,
+        initialSudokuField.flipVertically.rotateCW,
+        initialSudokuField.columnSwap(4, 5).columnSwap(0, 2).rowSwap(3, 4),
+        initialSudokuField.rotateCW.rotateCW.transpose
+      ).map(_.toRowUpdates)
+    )
+    .flatten
+    .iterator
 
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
-  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+  timers.startTimerAtFixedRate(SendNewSudoku,
+                               problemSendInterval
+  ) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessage {
-    case SendNewSudoku =>
-      context.log.debug("sending new sudoku problem")
-      val nextRowUpdates = rowUpdatesSeq.next
-      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
-      Behaviors.same
-    case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
-      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
-      Behaviors.same
-  }
+  def sending(): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SendNewSudoku =>
+        context.log.debug("sending new sudoku problem")
+        val nextRowUpdates = rowUpdatesSeq.next
+        sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
+        Behaviors.same
+      case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
+        context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+        Behaviors.same
+    }
 }
-

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProgressTracker {
 
@@ -13,33 +13,46 @@ object SudokuProgressTracker {
   final case class Result(sudoku: Sudoku) extends Response
 
   def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+            sudokuSolver: ActorRef[Response]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
-      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver)
+        .trackProgress(updatesInFlight = 0)
     }
 }
 
-class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-                            context: ActorContext[SudokuProgressTracker.Command],
-                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+class SudokuProgressTracker private (
+  rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+  context: ActorContext[SudokuProgressTracker.Command],
+  sudokuSolver: ActorRef[SudokuProgressTracker.Response]
+) {
 
   import SudokuProgressTracker._
 
-   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
-    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
-      rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
-      collectEndState()
-    case NewUpdatesInFlight(updateCount) =>
-      trackProgress(updatesInFlight + updateCount)
-    case msg: SudokuDetailState =>
-      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-      Behaviors.same
-  }
+  def trackProgress(updatesInFlight: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+        rowDetailProcessors.foreach ((_, processor) =>
+            processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self)
+        )
+        collectEndState()
+      case NewUpdatesInFlight(updateCount) =>
+        trackProgress(updatesInFlight + updateCount)
+      case msg: SudokuDetailState =>
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+        Behaviors.same
+    }
 
-  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+  def collectEndState(remainingRows: Int = 9,
+                      endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]
+  ): Behavior[Command] =
     Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
-        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        sudokuSolver ! Result(
+          (detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map {
+            case SudokuDetailState(_, state) => state
+          }
+        )
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
@@ -48,4 +61,3 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
         Behaviors.same
     }
 }
-

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 
 import scala.concurrent.duration._
 
@@ -13,40 +13,53 @@ object SudokuSolver {
   // SudokuSolver Protocol
   sealed trait Command
   final case class InitialRowUpdates(rowUpdates: Vector[SudokuDetailProcessor.RowUpdate],
-                                     replyTo: ActorRef[SudokuSolver.Response]) extends Command
+                                     replyTo: ActorRef[SudokuSolver.Response]
+  ) extends Command
   // Wrapped responses
-  private final case class SudokuDetailProcessorResponseWrapped(response: SudokuDetailProcessor.Response) extends Command
-  private final case class SudokuProgressTrackerResponseWrapped(response: SudokuProgressTracker.Response) extends Command
+  private final case class SudokuDetailProcessorResponseWrapped(
+    response: SudokuDetailProcessor.Response
+  ) extends Command
+  private final case class SudokuProgressTrackerResponseWrapped(
+    response: SudokuProgressTracker.Response
+  ) extends Command
   // My Responses
   sealed trait Response
   final case class SudokuSolution(sudoku: Sudoku) extends Response
 
   import SudokuDetailProcessor.UpdateSender
 
-  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[Command]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+  def genDetailProcessors[A <: SudokoDetailType: UpdateSender](
+    context: ActorContext[Command]
+  ): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
     import scala.language.implicitConversions
-    cellIndexesVector.map {
-      index =>
+    cellIndexesVector
+      .map { index =>
         val detailProcessorName = summon[UpdateSender[A]].processorName(index)
         val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
         (index, detailProcessor)
-    }.to(Map) // In Scala 2.13 this can be .to(Map)
+      }
+      .to(Map)
   }
 
   def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
-    Behaviors.supervise[Command] {
-      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
-        Behaviors.setup { context =>
-          new SudokuSolver(context, buffer).idle()
+    Behaviors
+      .supervise[Command] {
+        Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) {
+          buffer =>
+            Behaviors.setup { context =>
+              new SudokuSolver(context, buffer).idle()
+            }
         }
       }
-    }.onFailure[Exception](
-      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
-    )
+      .onFailure[Exception](
+        SupervisorStrategy
+          .restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+      )
 }
 
 class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
-                            buffer: StashBuffer[SudokuSolver.Command]) {
+                            buffer: StashBuffer[SudokuSolver.Command]
+) {
   import CellMappings._
   import SudokuSolver._
 
@@ -55,93 +68,98 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   val progressTrackerResponseMapper: ActorRef[SudokuProgressTracker.Response] =
     context.messageAdapter(response => SudokuProgressTrackerResponseWrapped(response))
 
-  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val rowDetailProcessors = genDetailProcessors[Row](context)
   private val columnDetailProcessors = genDetailProcessors[Column](context)
-  private val blockDetailProcessors  = genDetailProcessors[Block](context)
-  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+  private val blockDetailProcessors = genDetailProcessors[Block](context)
+  private val allDetailProcessors =
+    List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
 
   private val progressTracker =
-    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper),
+                  "sudoku-progress-tracker"
+    )
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessage {
+  def idle(): Behavior[Command] =
+    Behaviors.receiveMessage {
 
-    case InitialRowUpdates(rowUpdates, sender) =>
-      rowUpdates.foreach {
-        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
-          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
-      }
-      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
-      processRequest(Some(sender), System.currentTimeMillis())
-    case unexpectedMsg =>
-      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-      Behaviors.same
-
-  }
-
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
-    case SudokuDetailProcessorResponseWrapped(response) => response match {
-      case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
-        updates.foreach { (rowCellNr, newCellContent) =>
-
-          val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
-          val columnUpdate = Vector(columnCellNr -> newCellContent)
-          columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
-
-          val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
-          val blockUpdate = Vector(blockCellNr -> newCellContent)
-          blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+      case InitialRowUpdates(rowUpdates, sender) =>
+        rowUpdates.foreach {
+          case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+            rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+        processRequest(Some(sender), System.currentTimeMillis())
+      case unexpectedMsg =>
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
-      case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
-        updates.foreach { (colCellNr, newCellContent) =>
 
-          val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
-          val rowUpdate = Vector(rowCellNr -> newCellContent)
-          rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+    }
 
-          val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
-          val blockUpdate = Vector(blockCellNr -> newCellContent)
-          blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SudokuDetailProcessorResponseWrapped(response) =>
+        response match {
+          case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
+            updates.foreach { (rowCellNr, newCellContent) =>
+              val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
+              val columnUpdate = Vector(columnCellNr -> newCellContent)
+              columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+
+              val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
+              val blockUpdate = Vector(blockCellNr -> newCellContent)
+              blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
+            updates.foreach { (colCellNr, newCellContent) =>
+              val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
+              val rowUpdate = Vector(rowCellNr -> newCellContent)
+              rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+              val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
+              val blockUpdate = Vector(blockCellNr -> newCellContent)
+              blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
+            updates.foreach { (blockCellNr, newCellContent) =>
+              val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
+              val rowUpdate = Vector(rowCellNr -> newCellContent)
+              rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+              val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
+              val columnUpdate = Vector(columnCellNr -> newCellContent)
+              columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case unchanged @ SudokuDetailProcessor.SudokuDetailUnchanged =>
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+            Behaviors.same
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
-        Behaviors.same
-      case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
-        updates.foreach { (blockCellNr, newCellContent) =>
-
-          val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
-          val rowUpdate = Vector(rowCellNr -> newCellContent)
-          rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
-
-          val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
-          val columnUpdate = Vector(columnCellNr -> newCellContent)
-          columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+      case SudokuProgressTrackerResponseWrapped(result) =>
+        result match {
+          case SudokuProgressTracker.Result(sudoku) =>
+            context.log.info(
+              s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds"
+            )
+            requestor.get ! SudokuSolution(sudoku)
+            resetAllDetailProcessors()
+            buffer.unstashAll(idle())
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+      case msg: InitialRowUpdates if buffer.isFull =>
+        context.log.info(s"DROPPING REQUEST")
         Behaviors.same
-      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+      case msg: InitialRowUpdates =>
+        buffer.stash(msg)
         Behaviors.same
     }
-    case SudokuProgressTrackerResponseWrapped(result) => result match {
-      case SudokuProgressTracker.Result(sudoku) =>
-        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
-        requestor.get ! SudokuSolution(sudoku)
-        resetAllDetailProcessors()
-        buffer.unstashAll(idle())
-    }
-    case msg: InitialRowUpdates if buffer.isFull =>
-      context.log.info(s"DROPPING REQUEST")
-      Behaviors.same
-    case msg: InitialRowUpdates =>
-      buffer.stash(msg)
-      Behaviors.same
-  }
 
-  private def resetAllDetailProcessors(): Unit = {
+  private def resetAllDetailProcessors(): Unit =
     for {
       processors <- allDetailProcessors
       (_, processor) <- processors
     } processor ! SudokuDetailProcessor.ResetSudokuDetailState
-  }
 }

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS => Millis }
 
 object SudokuSolverSettings {
 

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -22,25 +22,28 @@ package org.lunatechlabs.dotty
 
 import akka.NotUsed
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
-import akka.actor.typed.scaladsl.{Behaviors, Routers}
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
-import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import akka.actor.typed.{ ActorSystem, Behavior, Terminated }
+import org.lunatechlabs.dotty.sudoku.{ SudokuProblemSender, SudokuSolver, SudokuSolverSettings }
 import scala.io.StdIn
-import Console.{GREEN, RESET}
+import scala.Console.{ GREEN, RESET }
 
 object Main {
-  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
-    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
-    // Start a SodukuSolver
-    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
-    // Start a Sudoku problem sender
-    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+  def apply(): Behavior[NotUsed] =
+    Behaviors.setup { context =>
+      val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+      // Start a SodukuSolver
+      val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+      // Start a Sudoku problem sender
+      context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings),
+                    "sudoku-problem-sender"
+      )
 
-    Behaviors.receiveSignal {
-      case (_, Terminated(_)) =>
-        Behaviors.stopped
+      Behaviors.receiveSignal {
+        case (_, Terminated(_)) =>
+          Behaviors.stopped
+      }
     }
-  }
 }
 
 object SudokuSolverMain {

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -15,8 +15,8 @@ object CellMappings {
     rowToBlockCoordinates(cellNr, columnNr)
 
   def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+    ((blockNr / 3) * 3 + cellNr / 3, (blockNr % 3) * 3 + cellNr % 3)
 
   def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+    ((blockNr % 3) * 3 + cellNr % 3, (blockNr / 3) * 3 + cellNr / 3)
 }

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -4,14 +4,14 @@ package org.lunatechlabs.dotty.sudoku
 extension reductionRules on (reductionSet: ReductionSet) {
 
   def applyReductionRuleOne: ReductionSet = {
-    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
+    val inputCellsGrouped = reductionSet.filter {_.size <= 7}.groupBy(identity)
     val completeInputCellGroups = inputCellsGrouped filter { (set, setOccurrences) =>
       set.size == setOccurrences.length
     }
     val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
     completeAndIsolatedValueSets.foldLeft(reductionSet) { (cells, caivSet) =>
-      cells.map {
-        cell => if (cell != caivSet) cell &~ caivSet else cell
+      cells.map { cell =>
+        if (cell != caivSet) cell &~ caivSet else cell
       }
     }
   }
@@ -25,16 +25,17 @@ extension reductionRules on (reductionSet: ReductionSet) {
     }
 
     val cellIndexesToValues =
-      CELLPossibleValues.zip(valueOccurrences)
-        .groupBy ((value, occurrence) => occurrence)
-        .filter  ((loc, occ) => loc.length == occ.length && loc.length <= 6 )
+      CELLPossibleValues
+        .zip(valueOccurrences)
+        .groupBy ((value, occurrence) => occurrence )
+        .filter { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
 
     val cellIndexListToReducedValue = cellIndexesToValues.map { (index, seq) =>
       (index, (seq.map ((value, _) => value )).toSet)
     }
 
-    val cellIndexToReducedValue = cellIndexListToReducedValue flatMap { (cellIndexList, reducedValue) => 
-      cellIndexList map { cellIndex => cellIndex -> reducedValue }
+    val cellIndexToReducedValue = cellIndexListToReducedValue.flatMap { (cellIndexList, reducedValue) =>
+      cellIndexList.map(cellIndex => cellIndex -> reducedValue)
     }
 
     reductionSet.zipWithIndex.foldRight(Vector.empty[CellContent]) {

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -31,7 +31,6 @@ object SudokuDetailProcessor {
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit
-
     def processorName(id: Int): String
   }
 
@@ -39,19 +38,19 @@ object SudokuDetailProcessor {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit = {
       sender ! RowUpdate(id, cellUpdates)
     }
-    override def processorName(id: Int): String = s"row-processor-$id"
+    def processorName(id: Int): String = s"row-processor-$id"
   }
 
   given UpdateSender[Column] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"col-processor-$id"
+    def processorName(id: Int): String = s"col-processor-$id"
   }
 
   given UpdateSender[Block] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
       sender ! BlockUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"blk-processor-$id"
+    def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -2,8 +2,8 @@ package org.lunatechlabs.dotty.sudoku
 
 import java.io.File
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProblemSender {
 
@@ -13,11 +13,13 @@ object SudokuProblemSender {
   private final case class SolutionWrapper(result: SudokuSolver.Response) extends Command
 
   private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
-    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
-      .map((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
+    SudokuIO
+      .readSudokuFromFile(new File("sudokus/001.sudoku"))
+      .map ((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
 
   def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
-            sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
+            sudokuSolverSettings: SudokuSolverSettings
+  ): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
         new SudokuProblemSender(sudokuSolver, context, timers, sudokuSolverSettings).sending()
@@ -28,7 +30,8 @@ object SudokuProblemSender {
 class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
                                    context: ActorContext[SudokuProblemSender.Command],
                                    timers: TimerScheduler[SudokuProblemSender.Command],
-                                   sudokuSolverSettings: SudokuSolverSettings) {
+                                   sudokuSolverSettings: SudokuSolverSettings
+) {
   import SudokuProblemSender._
 
   private val solutionWrapper: ActorRef[SudokuSolver.Response] =
@@ -36,45 +39,51 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
 
   private val initialSudokuField = rowUpdates.toSudokuField
 
-  private val rowUpdatesSeq = LazyList.continually(
-    Vector(
-      initialSudokuField,
-      initialSudokuField.flipVertically,
-      initialSudokuField.flipHorizontally,
-      initialSudokuField.flipHorizontally.flipVertically,
-      initialSudokuField.flipVertically.flipHorizontally,
-      initialSudokuField.columnSwap(0,1),
-      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW,
-      initialSudokuField.rotateCCW,
-      initialSudokuField.rotateCW.rotateCW,
-      initialSudokuField.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.flipVertically.transpose,
-      initialSudokuField.flipVertically.rotateCW,
-      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
-      initialSudokuField.rotateCW.rotateCW.transpose
-    ).map(_.toRowUpdates)).flatten.iterator
+  private val rowUpdatesSeq = LazyList
+    .continually(
+      Vector(
+        initialSudokuField,
+        initialSudokuField.flipVertically,
+        initialSudokuField.flipHorizontally,
+        initialSudokuField.flipHorizontally.flipVertically,
+        initialSudokuField.flipVertically.flipHorizontally,
+        initialSudokuField.columnSwap(0, 1),
+        initialSudokuField.rowSwap(4, 5).rowSwap(0, 2),
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW,
+        initialSudokuField.rotateCCW,
+        initialSudokuField.rotateCW.rotateCW,
+        initialSudokuField.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.flipVertically.transpose,
+        initialSudokuField.flipVertically.rotateCW,
+        initialSudokuField.columnSwap(4, 5).columnSwap(0, 2).rowSwap(3, 4),
+        initialSudokuField.rotateCW.rotateCW.transpose
+      ).map(_.toRowUpdates)
+    )
+    .flatten
+    .iterator
 
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
-  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+  timers.startTimerAtFixedRate(SendNewSudoku,
+                               problemSendInterval
+  ) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessage {
-    case SendNewSudoku =>
-      context.log.debug("sending new sudoku problem")
-      val nextRowUpdates = rowUpdatesSeq.next
-      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
-      Behaviors.same
-    case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
-      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
-      Behaviors.same
-  }
+  def sending(): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SendNewSudoku =>
+        context.log.debug("sending new sudoku problem")
+        val nextRowUpdates = rowUpdatesSeq.next
+        sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
+        Behaviors.same
+      case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
+        context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+        Behaviors.same
+    }
 }
-

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProgressTracker {
 
@@ -13,33 +13,46 @@ object SudokuProgressTracker {
   final case class Result(sudoku: Sudoku) extends Response
 
   def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+            sudokuSolver: ActorRef[Response]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
-      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver)
+        .trackProgress(updatesInFlight = 0)
     }
 }
 
-class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-                            context: ActorContext[SudokuProgressTracker.Command],
-                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+class SudokuProgressTracker private (
+  rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+  context: ActorContext[SudokuProgressTracker.Command],
+  sudokuSolver: ActorRef[SudokuProgressTracker.Response]
+) {
 
   import SudokuProgressTracker._
 
-   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
-    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
-      rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
-      collectEndState()
-    case NewUpdatesInFlight(updateCount) =>
-      trackProgress(updatesInFlight + updateCount)
-    case msg: SudokuDetailState =>
-      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-      Behaviors.same
-  }
+  def trackProgress(updatesInFlight: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+        rowDetailProcessors.foreach ((_, processor) =>
+            processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self)
+        )
+        collectEndState()
+      case NewUpdatesInFlight(updateCount) =>
+        trackProgress(updatesInFlight + updateCount)
+      case msg: SudokuDetailState =>
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+        Behaviors.same
+    }
 
-  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+  def collectEndState(remainingRows: Int = 9,
+                      endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]
+  ): Behavior[Command] =
     Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
-        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        sudokuSolver ! Result(
+          (detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map {
+            case SudokuDetailState(_, state) => state
+          }
+        )
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
@@ -48,4 +61,3 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
         Behaviors.same
     }
 }
-

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 
 import scala.concurrent.duration._
 
@@ -13,40 +13,53 @@ object SudokuSolver {
   // SudokuSolver Protocol
   sealed trait Command
   final case class InitialRowUpdates(rowUpdates: Vector[SudokuDetailProcessor.RowUpdate],
-                                     replyTo: ActorRef[SudokuSolver.Response]) extends Command
+                                     replyTo: ActorRef[SudokuSolver.Response]
+  ) extends Command
   // Wrapped responses
-  private final case class SudokuDetailProcessorResponseWrapped(response: SudokuDetailProcessor.Response) extends Command
-  private final case class SudokuProgressTrackerResponseWrapped(response: SudokuProgressTracker.Response) extends Command
+  private final case class SudokuDetailProcessorResponseWrapped(
+    response: SudokuDetailProcessor.Response
+  ) extends Command
+  private final case class SudokuProgressTrackerResponseWrapped(
+    response: SudokuProgressTracker.Response
+  ) extends Command
   // My Responses
   sealed trait Response
   final case class SudokuSolution(sudoku: Sudoku) extends Response
 
   import SudokuDetailProcessor.UpdateSender
 
-  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[Command]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+  def genDetailProcessors[A <: SudokoDetailType: UpdateSender](
+    context: ActorContext[Command]
+  ): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
     import scala.language.implicitConversions
-    cellIndexesVector.map {
-      index =>
+    cellIndexesVector
+      .map { index =>
         val detailProcessorName = summon[UpdateSender[A]].processorName(index)
         val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
         (index, detailProcessor)
-    }.to(Map) // In Scala 2.13 this can be .to(Map)
+      }
+      .to(Map)
   }
 
   def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
-    Behaviors.supervise[Command] {
-      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
-        Behaviors.setup { context =>
-          new SudokuSolver(context, buffer).idle()
+    Behaviors
+      .supervise[Command] {
+        Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) {
+          buffer =>
+            Behaviors.setup { context =>
+              new SudokuSolver(context, buffer).idle()
+            }
         }
       }
-    }.onFailure[Exception](
-      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
-    )
+      .onFailure[Exception](
+        SupervisorStrategy
+          .restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+      )
 }
 
 class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
-                            buffer: StashBuffer[SudokuSolver.Command]) {
+                            buffer: StashBuffer[SudokuSolver.Command]
+) {
   import CellMappings._
   import SudokuSolver._
 
@@ -55,93 +68,98 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   val progressTrackerResponseMapper: ActorRef[SudokuProgressTracker.Response] =
     context.messageAdapter(response => SudokuProgressTrackerResponseWrapped(response))
 
-  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val rowDetailProcessors = genDetailProcessors[Row](context)
   private val columnDetailProcessors = genDetailProcessors[Column](context)
-  private val blockDetailProcessors  = genDetailProcessors[Block](context)
-  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+  private val blockDetailProcessors = genDetailProcessors[Block](context)
+  private val allDetailProcessors =
+    List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
 
   private val progressTracker =
-    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper),
+                  "sudoku-progress-tracker"
+    )
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessage {
+  def idle(): Behavior[Command] =
+    Behaviors.receiveMessage {
 
-    case InitialRowUpdates(rowUpdates, sender) =>
-      rowUpdates.foreach {
-        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
-          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
-      }
-      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
-      processRequest(Some(sender), System.currentTimeMillis())
-    case unexpectedMsg =>
-      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-      Behaviors.same
-
-  }
-
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
-    case SudokuDetailProcessorResponseWrapped(response) => response match {
-      case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
-        updates.foreach { (rowCellNr, newCellContent) =>
-
-          val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
-          val columnUpdate = Vector(columnCellNr -> newCellContent)
-          columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
-
-          val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
-          val blockUpdate = Vector(blockCellNr -> newCellContent)
-          blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+      case InitialRowUpdates(rowUpdates, sender) =>
+        rowUpdates.foreach {
+          case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+            rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+        processRequest(Some(sender), System.currentTimeMillis())
+      case unexpectedMsg =>
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
-      case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
-        updates.foreach { (colCellNr, newCellContent) =>
 
-          val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
-          val rowUpdate = Vector(rowCellNr -> newCellContent)
-          rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+    }
 
-          val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
-          val blockUpdate = Vector(blockCellNr -> newCellContent)
-          blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SudokuDetailProcessorResponseWrapped(response) =>
+        response match {
+          case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
+            updates.foreach { (rowCellNr, newCellContent) =>
+              val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
+              val columnUpdate = Vector(columnCellNr -> newCellContent)
+              columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+
+              val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
+              val blockUpdate = Vector(blockCellNr -> newCellContent)
+              blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
+            updates.foreach { (colCellNr, newCellContent) =>
+              val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
+              val rowUpdate = Vector(rowCellNr -> newCellContent)
+              rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+              val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
+              val blockUpdate = Vector(blockCellNr -> newCellContent)
+              blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
+            updates.foreach { (blockCellNr, newCellContent) =>
+              val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
+              val rowUpdate = Vector(rowCellNr -> newCellContent)
+              rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+              val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
+              val columnUpdate = Vector(columnCellNr -> newCellContent)
+              columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case unchanged @ SudokuDetailProcessor.SudokuDetailUnchanged =>
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+            Behaviors.same
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
-        Behaviors.same
-      case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
-        updates.foreach { (blockCellNr, newCellContent) =>
-
-          val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
-          val rowUpdate = Vector(rowCellNr -> newCellContent)
-          rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
-
-          val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
-          val columnUpdate = Vector(columnCellNr -> newCellContent)
-          columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+      case SudokuProgressTrackerResponseWrapped(result) =>
+        result match {
+          case SudokuProgressTracker.Result(sudoku) =>
+            context.log.info(
+              s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds"
+            )
+            requestor.get ! SudokuSolution(sudoku)
+            resetAllDetailProcessors()
+            buffer.unstashAll(idle())
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+      case msg: InitialRowUpdates if buffer.isFull =>
+        context.log.info(s"DROPPING REQUEST")
         Behaviors.same
-      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+      case msg: InitialRowUpdates =>
+        buffer.stash(msg)
         Behaviors.same
     }
-    case SudokuProgressTrackerResponseWrapped(result) => result match {
-      case SudokuProgressTracker.Result(sudoku) =>
-        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
-        requestor.get ! SudokuSolution(sudoku)
-        resetAllDetailProcessors()
-        buffer.unstashAll(idle())
-    }
-    case msg: InitialRowUpdates if buffer.isFull =>
-      context.log.info(s"DROPPING REQUEST")
-      Behaviors.same
-    case msg: InitialRowUpdates =>
-      buffer.stash(msg)
-      Behaviors.same
-  }
 
-  private def resetAllDetailProcessors(): Unit = {
+  private def resetAllDetailProcessors(): Unit =
     for {
       processors <- allDetailProcessors
       (_, processor) <- processors
     } processor ! SudokuDetailProcessor.ResetSudokuDetailState
-  }
 }

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS => Millis }
 
 object SudokuSolverSettings {
 

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -22,25 +22,28 @@ package org.lunatechlabs.dotty
 
 import akka.NotUsed
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
-import akka.actor.typed.scaladsl.{Behaviors, Routers}
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
-import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import akka.actor.typed.{ ActorSystem, Behavior, Terminated }
+import org.lunatechlabs.dotty.sudoku.{ SudokuProblemSender, SudokuSolver, SudokuSolverSettings }
 import scala.io.StdIn
-import Console.{GREEN, RESET}
+import scala.Console.{ GREEN, RESET }
 
 object Main {
-  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
-    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
-    // Start a SodukuSolver
-    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
-    // Start a Sudoku problem sender
-    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+  def apply(): Behavior[NotUsed] =
+    Behaviors.setup { context =>
+      val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+      // Start a SodukuSolver
+      val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+      // Start a Sudoku problem sender
+      context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings),
+                    "sudoku-problem-sender"
+      )
 
-    Behaviors.receiveSignal {
-      case (_, Terminated(_)) =>
-        Behaviors.stopped
+      Behaviors.receiveSignal {
+        case (_, Terminated(_)) =>
+          Behaviors.stopped
+      }
     }
-  }
 }
 
 object SudokuSolverMain {

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -15,8 +15,8 @@ object CellMappings {
     rowToBlockCoordinates(cellNr, columnNr)
 
   def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+    ((blockNr / 3) * 3 + cellNr / 3, (blockNr % 3) * 3 + cellNr % 3)
 
   def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+    ((blockNr % 3) * 3 + cellNr % 3, (blockNr / 3) * 3 + cellNr / 3)
 }

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -4,14 +4,14 @@ package org.lunatechlabs.dotty.sudoku
 extension reductionRules on (reductionSet: ReductionSet) {
 
   def applyReductionRuleOne: ReductionSet = {
-    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
+    val inputCellsGrouped = reductionSet.filter {_.size <= 7}.groupBy(identity)
     val completeInputCellGroups = inputCellsGrouped filter { (set, setOccurrences) =>
       set.size == setOccurrences.length
     }
     val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
     completeAndIsolatedValueSets.foldLeft(reductionSet) { (cells, caivSet) =>
-      cells.map {
-        cell => if (cell != caivSet) cell &~ caivSet else cell
+      cells.map { cell =>
+        if (cell != caivSet) cell &~ caivSet else cell
       }
     }
   }
@@ -25,16 +25,17 @@ extension reductionRules on (reductionSet: ReductionSet) {
     }
 
     val cellIndexesToValues =
-      CELLPossibleValues.zip(valueOccurrences)
-        .groupBy ((value, occurrence) => occurrence)
-        .filter  ((loc, occ) => loc.length == occ.length && loc.length <= 6 )
+      CELLPossibleValues
+        .zip(valueOccurrences)
+        .groupBy ((value, occurrence) => occurrence )
+        .filter { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
 
     val cellIndexListToReducedValue = cellIndexesToValues.map { (index, seq) =>
       (index, (seq.map ((value, _) => value )).toSet)
     }
 
-    val cellIndexToReducedValue = cellIndexListToReducedValue flatMap { (cellIndexList, reducedValue) => 
-      cellIndexList map { cellIndex => cellIndex -> reducedValue }
+    val cellIndexToReducedValue = cellIndexListToReducedValue.flatMap { (cellIndexList, reducedValue) =>
+      cellIndexList.map(cellIndex => cellIndex -> reducedValue)
     }
 
     reductionSet.zipWithIndex.foldRight(Vector.empty[CellContent]) {

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -35,7 +35,6 @@ object SudokuDetailProcessor {
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit
-
     def processorName(id: Int): String
   }
 
@@ -43,19 +42,19 @@ object SudokuDetailProcessor {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit = {
       sender ! RowUpdate(id, cellUpdates)
     }
-    override def processorName(id: Int): String = s"row-processor-$id"
+    def processorName(id: Int): String = s"row-processor-$id"
   }
 
   given UpdateSender[Column] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"col-processor-$id"
+    def processorName(id: Int): String = s"col-processor-$id"
   }
 
   given UpdateSender[Block] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
       sender ! BlockUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"blk-processor-$id"
+    def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -2,8 +2,8 @@ package org.lunatechlabs.dotty.sudoku
 
 import java.io.File
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProblemSender {
 
@@ -14,14 +14,14 @@ object SudokuProblemSender {
   }
   export Command._
 
-  
-
   private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
-    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
-      .map((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
+    SudokuIO
+      .readSudokuFromFile(new File("sudokus/001.sudoku"))
+      .map ((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
 
   def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
-            sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
+            sudokuSolverSettings: SudokuSolverSettings
+  ): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
         new SudokuProblemSender(sudokuSolver, context, timers, sudokuSolverSettings).sending()
@@ -32,7 +32,8 @@ object SudokuProblemSender {
 class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
                                    context: ActorContext[SudokuProblemSender.Command],
                                    timers: TimerScheduler[SudokuProblemSender.Command],
-                                   sudokuSolverSettings: SudokuSolverSettings) {
+                                   sudokuSolverSettings: SudokuSolverSettings
+) {
   import SudokuProblemSender._
 
   private val solutionWrapper: ActorRef[SudokuSolver.Response] =
@@ -40,45 +41,51 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
 
   private val initialSudokuField = rowUpdates.toSudokuField
 
-  private val rowUpdatesSeq = LazyList.continually(
-    Vector(
-      initialSudokuField,
-      initialSudokuField.flipVertically,
-      initialSudokuField.flipHorizontally,
-      initialSudokuField.flipHorizontally.flipVertically,
-      initialSudokuField.flipVertically.flipHorizontally,
-      initialSudokuField.columnSwap(0,1),
-      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW,
-      initialSudokuField.rotateCCW,
-      initialSudokuField.rotateCW.rotateCW,
-      initialSudokuField.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.flipVertically.transpose,
-      initialSudokuField.flipVertically.rotateCW,
-      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
-      initialSudokuField.rotateCW.rotateCW.transpose
-    ).map(_.toRowUpdates)).flatten.iterator
+  private val rowUpdatesSeq = LazyList
+    .continually(
+      Vector(
+        initialSudokuField,
+        initialSudokuField.flipVertically,
+        initialSudokuField.flipHorizontally,
+        initialSudokuField.flipHorizontally.flipVertically,
+        initialSudokuField.flipVertically.flipHorizontally,
+        initialSudokuField.columnSwap(0, 1),
+        initialSudokuField.rowSwap(4, 5).rowSwap(0, 2),
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW,
+        initialSudokuField.rotateCCW,
+        initialSudokuField.rotateCW.rotateCW,
+        initialSudokuField.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.flipVertically.transpose,
+        initialSudokuField.flipVertically.rotateCW,
+        initialSudokuField.columnSwap(4, 5).columnSwap(0, 2).rowSwap(3, 4),
+        initialSudokuField.rotateCW.rotateCW.transpose
+      ).map(_.toRowUpdates)
+    )
+    .flatten
+    .iterator
 
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
-  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+  timers.startTimerAtFixedRate(SendNewSudoku,
+                               problemSendInterval
+  ) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[Command] = Behaviors.receiveMessage {
-    case SendNewSudoku =>
-      context.log.debug("sending new sudoku problem")
-      val nextRowUpdates = rowUpdatesSeq.next
-      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
-      Behaviors.same
-    case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
-      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
-      Behaviors.same
-  }
+  def sending(): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SendNewSudoku =>
+        context.log.debug("sending new sudoku problem")
+        val nextRowUpdates = rowUpdatesSeq.next
+        sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, solutionWrapper)
+        Behaviors.same
+      case SolutionWrapper(solution: SudokuSolver.SudokuSolution) =>
+        context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+        Behaviors.same
+    }
 }
-

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProgressTracker {
 
@@ -18,33 +18,46 @@ object SudokuProgressTracker {
   export Response._
 
   def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+            sudokuSolver: ActorRef[Response]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
-      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver)
+        .trackProgress(updatesInFlight = 0)
     }
 }
 
-class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-                            context: ActorContext[SudokuProgressTracker.Command],
-                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+class SudokuProgressTracker private (
+  rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+  context: ActorContext[SudokuProgressTracker.Command],
+  sudokuSolver: ActorRef[SudokuProgressTracker.Response]
+) {
 
   import SudokuProgressTracker._
 
-   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
-    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
-      rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
-      collectEndState()
-    case NewUpdatesInFlight(updateCount) =>
-      trackProgress(updatesInFlight + updateCount)
-    case msg: SudokuDetailState =>
-      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-      Behaviors.same
-  }
+  def trackProgress(updatesInFlight: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+        rowDetailProcessors.foreach ((_, processor) =>
+            processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self)
+        )
+        collectEndState()
+      case NewUpdatesInFlight(updateCount) =>
+        trackProgress(updatesInFlight + updateCount)
+      case msg: SudokuDetailState =>
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+        Behaviors.same
+    }
 
-  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+  def collectEndState(remainingRows: Int = 9,
+                      endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]
+  ): Behavior[Command] =
     Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
-        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        sudokuSolver ! Result(
+          (detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map {
+            case SudokuDetailState(_, state) => state
+          }
+        )
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
@@ -53,4 +66,3 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
         Behaviors.same
     }
 }
-

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 
 import scala.concurrent.duration._
 
@@ -28,30 +28,38 @@ object SudokuSolver {
   
   import SudokuDetailProcessor.UpdateSender
 
-  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[Command]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+  def genDetailProcessors[A <: SudokoDetailType: UpdateSender](
+    context: ActorContext[Command]
+  ): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
     import scala.language.implicitConversions
-    cellIndexesVector.map {
-      index =>
+    cellIndexesVector
+      .map { index =>
         val detailProcessorName = summon[UpdateSender[A]].processorName(index)
         val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
         (index, detailProcessor)
-    }.to(Map) // In Scala 2.13 this can be .to(Map)
+      }
+      .to(Map)
   }
 
   def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
-    Behaviors.supervise[Command] {
-      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
-        Behaviors.setup { context =>
-          new SudokuSolver(context, buffer).idle()
+    Behaviors
+      .supervise[Command] {
+        Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) {
+          buffer =>
+            Behaviors.setup { context =>
+              new SudokuSolver(context, buffer).idle()
+            }
         }
       }
-    }.onFailure[Exception](
-      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
-    )
+      .onFailure[Exception](
+        SupervisorStrategy
+          .restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+      )
 }
 
 class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
-                            buffer: StashBuffer[SudokuSolver.Command]) {
+                            buffer: StashBuffer[SudokuSolver.Command]
+) {
   import CellMappings._
   import SudokuSolver._
 
@@ -60,93 +68,98 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
   val progressTrackerResponseMapper: ActorRef[SudokuProgressTracker.Response] =
     context.messageAdapter(response => SudokuProgressTrackerResponseWrapped(response))
 
-  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val rowDetailProcessors = genDetailProcessors[Row](context)
   private val columnDetailProcessors = genDetailProcessors[Column](context)
-  private val blockDetailProcessors  = genDetailProcessors[Block](context)
-  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+  private val blockDetailProcessors = genDetailProcessors[Block](context)
+  private val allDetailProcessors =
+    List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
 
   private val progressTracker =
-    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper), "sudoku-progress-tracker")
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, progressTrackerResponseMapper),
+                  "sudoku-progress-tracker"
+    )
 
-  def idle(): Behavior[Command] = Behaviors.receiveMessage {
+  def idle(): Behavior[Command] =
+    Behaviors.receiveMessage {
 
-    case InitialRowUpdates(rowUpdates, sender) =>
-      rowUpdates.foreach {
-        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
-          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
-      }
-      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
-      processRequest(Some(sender), System.currentTimeMillis())
-    case unexpectedMsg =>
-      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-      Behaviors.same
-
-  }
-
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] = Behaviors.receiveMessage {
-    case SudokuDetailProcessorResponseWrapped(response) => response match {
-      case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
-        updates.foreach { (rowCellNr, newCellContent) =>
-
-          val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
-          val columnUpdate = Vector(columnCellNr -> newCellContent)
-          columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
-
-          val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
-          val blockUpdate = Vector(blockCellNr -> newCellContent)
-          blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+      case InitialRowUpdates(rowUpdates, sender) =>
+        rowUpdates.foreach {
+          case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+            rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, detailProcessorResponseMapper)
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+        processRequest(Some(sender), System.currentTimeMillis())
+      case unexpectedMsg =>
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
-      case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
-        updates.foreach { (colCellNr, newCellContent) =>
 
-          val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
-          val rowUpdate = Vector(rowCellNr -> newCellContent)
-          rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+    }
 
-          val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
-          val blockUpdate = Vector(blockCellNr -> newCellContent)
-          blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case SudokuDetailProcessorResponseWrapped(response) =>
+        response match {
+          case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
+            updates.foreach { (rowCellNr, newCellContent) =>
+              val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
+              val columnUpdate = Vector(columnCellNr -> newCellContent)
+              columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+
+              val (blockNr, blockCellNr) = rowToBlockCoordinates(rowNr, rowCellNr)
+              val blockUpdate = Vector(blockCellNr -> newCellContent)
+              blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
+            updates.foreach { (colCellNr, newCellContent) =>
+              val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
+              val rowUpdate = Vector(rowCellNr -> newCellContent)
+              rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+              val (blockNr, blockCellNr) = columnToBlockCoordinates(columnNr, colCellNr)
+              val blockUpdate = Vector(blockCellNr -> newCellContent)
+              blockDetailProcessors(blockNr) ! SudokuDetailProcessor.Update(blockUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
+            updates.foreach { (blockCellNr, newCellContent) =>
+              val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
+              val rowUpdate = Vector(rowCellNr -> newCellContent)
+              rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
+
+              val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
+              val columnUpdate = Vector(columnCellNr -> newCellContent)
+              columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+            }
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+            Behaviors.same
+          case unchanged @ SudokuDetailProcessor.SudokuDetailUnchanged =>
+            progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+            Behaviors.same
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
-        Behaviors.same
-      case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
-        updates.foreach { (blockCellNr, newCellContent) =>
-
-          val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
-          val rowUpdate = Vector(rowCellNr -> newCellContent)
-          rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, detailProcessorResponseMapper)
-
-          val (columnNr, columnCellNr) = blockToColumnCoordinates(blockNr, blockCellNr)
-          val columnUpdate = Vector(columnCellNr -> newCellContent)
-          columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, detailProcessorResponseMapper)
+      case SudokuProgressTrackerResponseWrapped(result) =>
+        result match {
+          case SudokuProgressTracker.Result(sudoku) =>
+            context.log.info(
+              s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds"
+            )
+            requestor.get ! SudokuSolution(sudoku)
+            resetAllDetailProcessors()
+            buffer.unstashAll(idle())
         }
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
+      case msg: InitialRowUpdates if buffer.isFull =>
+        context.log.info(s"DROPPING REQUEST")
         Behaviors.same
-      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
-        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
+      case msg: InitialRowUpdates =>
+        buffer.stash(msg)
         Behaviors.same
     }
-    case SudokuProgressTrackerResponseWrapped(result) => result match {
-      case SudokuProgressTracker.Result(sudoku) =>
-        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
-        requestor.get ! SudokuSolution(sudoku)
-        resetAllDetailProcessors()
-        buffer.unstashAll(idle())
-    }
-    case msg: InitialRowUpdates if buffer.isFull =>
-      context.log.info(s"DROPPING REQUEST")
-      Behaviors.same
-    case msg: InitialRowUpdates =>
-      buffer.stash(msg)
-      Behaviors.same
-  }
 
-  private def resetAllDetailProcessors(): Unit = {
+  private def resetAllDetailProcessors(): Unit =
     for {
       processors <- allDetailProcessors
       (_, processor) <- processors
     } processor ! SudokuDetailProcessor.ResetSudokuDetailState
-  }
 }

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS => Millis }
 
 object SudokuSolverSettings {
 

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -22,25 +22,28 @@ package org.lunatechlabs.dotty
 
 import akka.NotUsed
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
-import akka.actor.typed.scaladsl.{Behaviors, Routers}
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
-import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import akka.actor.typed.{ ActorSystem, Behavior, Terminated }
+import org.lunatechlabs.dotty.sudoku.{ SudokuProblemSender, SudokuSolver, SudokuSolverSettings }
 import scala.io.StdIn
-import Console.{GREEN, RESET}
+import scala.Console.{ GREEN, RESET }
 
 object Main {
-  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
-    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
-    // Start a SodukuSolver
-    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
-    // Start a Sudoku problem sender
-    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+  def apply(): Behavior[NotUsed] =
+    Behaviors.setup { context =>
+      val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+      // Start a SodukuSolver
+      val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+      // Start a Sudoku problem sender
+      context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings),
+                    "sudoku-problem-sender"
+      )
 
-    Behaviors.receiveSignal {
-      case (_, Terminated(_)) =>
-        Behaviors.stopped
+      Behaviors.receiveSignal {
+        case (_, Terminated(_)) =>
+          Behaviors.stopped
+      }
     }
-  }
 }
 
 object SudokuSolverMain {

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -15,8 +15,8 @@ object CellMappings {
     rowToBlockCoordinates(cellNr, columnNr)
 
   def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+    ((blockNr / 3) * 3 + cellNr / 3, (blockNr % 3) * 3 + cellNr % 3)
 
   def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+    ((blockNr % 3) * 3 + cellNr % 3, (blockNr / 3) * 3 + cellNr / 3)
 }

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -4,14 +4,14 @@ package org.lunatechlabs.dotty.sudoku
 extension reductionRules on (reductionSet: ReductionSet) {
 
   def applyReductionRuleOne: ReductionSet = {
-    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
+    val inputCellsGrouped = reductionSet.filter {_.size <= 7}.groupBy(identity)
     val completeInputCellGroups = inputCellsGrouped filter { (set, setOccurrences) =>
       set.size == setOccurrences.length
     }
     val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
     completeAndIsolatedValueSets.foldLeft(reductionSet) { (cells, caivSet) =>
-      cells.map {
-        cell => if (cell != caivSet) cell &~ caivSet else cell
+      cells.map { cell =>
+        if (cell != caivSet) cell &~ caivSet else cell
       }
     }
   }
@@ -25,16 +25,17 @@ extension reductionRules on (reductionSet: ReductionSet) {
     }
 
     val cellIndexesToValues =
-      CELLPossibleValues.zip(valueOccurrences)
-        .groupBy ((value, occurrence) => occurrence)
-        .filter  ((loc, occ) => loc.length == occ.length && loc.length <= 6 )
+      CELLPossibleValues
+        .zip(valueOccurrences)
+        .groupBy ((value, occurrence) => occurrence )
+        .filter { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
 
     val cellIndexListToReducedValue = cellIndexesToValues.map { (index, seq) =>
       (index, (seq.map ((value, _) => value )).toSet)
     }
 
-    val cellIndexToReducedValue = cellIndexListToReducedValue flatMap { (cellIndexList, reducedValue) => 
-      cellIndexList map { cellIndex => cellIndex -> reducedValue }
+    val cellIndexToReducedValue = cellIndexListToReducedValue.flatMap { (cellIndexList, reducedValue) =>
+      cellIndexList.map(cellIndex => cellIndex -> reducedValue)
     }
 
     reductionSet.zipWithIndex.foldRight(Vector.empty[CellContent]) {

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -35,7 +35,6 @@ object SudokuDetailProcessor {
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit
-
     def processorName(id: Int): String
   }
 
@@ -43,19 +42,19 @@ object SudokuDetailProcessor {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit = {
       sender ! RowUpdate(id, cellUpdates)
     }
-    override def processorName(id: Int): String = s"row-processor-$id"
+    def processorName(id: Int): String = s"row-processor-$id"
   }
 
   given UpdateSender[Column] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"col-processor-$id"
+    def processorName(id: Int): String = s"col-processor-$id"
   }
 
   given UpdateSender[Block] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
       sender ! BlockUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"blk-processor-$id"
+    def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -2,8 +2,8 @@ package org.lunatechlabs.dotty.sudoku
 
 import java.io.File
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProblemSender {
 
@@ -15,8 +15,9 @@ object SudokuProblemSender {
   type CommandAndResponses = Command | SudokuSolver.Response
 
   private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
-    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
-      .map((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
+    SudokuIO
+      .readSudokuFromFile(new File("sudokus/001.sudoku"))
+      .map ((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
 
   def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
             sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
@@ -35,45 +36,51 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
 
   private val initialSudokuField = rowUpdates.toSudokuField
 
-  private val rowUpdatesSeq = LazyList.continually(
-    Vector(
-      initialSudokuField,
-      initialSudokuField.flipVertically,
-      initialSudokuField.flipHorizontally,
-      initialSudokuField.flipHorizontally.flipVertically,
-      initialSudokuField.flipVertically.flipHorizontally,
-      initialSudokuField.columnSwap(0,1),
-      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW,
-      initialSudokuField.rotateCCW,
-      initialSudokuField.rotateCW.rotateCW,
-      initialSudokuField.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.flipVertically.transpose,
-      initialSudokuField.flipVertically.rotateCW,
-      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
-      initialSudokuField.rotateCW.rotateCW.transpose
-    ).map(_.toRowUpdates)).flatten.iterator
+  private val rowUpdatesSeq = LazyList
+    .continually(
+      Vector(
+        initialSudokuField,
+        initialSudokuField.flipVertically,
+        initialSudokuField.flipHorizontally,
+        initialSudokuField.flipHorizontally.flipVertically,
+        initialSudokuField.flipVertically.flipHorizontally,
+        initialSudokuField.columnSwap(0, 1),
+        initialSudokuField.rowSwap(4, 5).rowSwap(0, 2),
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW,
+        initialSudokuField.rotateCCW,
+        initialSudokuField.rotateCW.rotateCW,
+        initialSudokuField.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.flipVertically.transpose,
+        initialSudokuField.flipVertically.rotateCW,
+        initialSudokuField.columnSwap(4, 5).columnSwap(0, 2).rowSwap(3, 4),
+        initialSudokuField.rotateCW.rotateCW.transpose
+      ).map(_.toRowUpdates)
+    )
+    .flatten
+    .iterator
 
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
-  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+  timers.startTimerAtFixedRate(SendNewSudoku,
+                               problemSendInterval
+  ) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[CommandAndResponses] = Behaviors.receiveMessage {
-    case SendNewSudoku =>
-      context.log.debug("sending new sudoku problem")
-      val nextRowUpdates = rowUpdatesSeq.next
-      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, context.self)
-      Behaviors.same
-    case solution: SudokuSolver.SudokuSolution =>
-      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
-      Behaviors.same
-  }
+  def sending(): Behavior[CommandAndResponses] = 
+    Behaviors.receiveMessage {
+      case SendNewSudoku =>
+        context.log.debug("sending new sudoku problem")
+        val nextRowUpdates = rowUpdatesSeq.next
+        sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, context.self)
+        Behaviors.same
+      case solution: SudokuSolver.SudokuSolution =>
+        context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+        Behaviors.same
+    }
 }
-

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProgressTracker {
 
@@ -18,33 +18,46 @@ object SudokuProgressTracker {
   export Response._
 
   def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+            sudokuSolver: ActorRef[Response]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
-      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver)
+        .trackProgress(updatesInFlight = 0)
     }
 }
 
-class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-                            context: ActorContext[SudokuProgressTracker.Command],
-                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+class SudokuProgressTracker private (
+  rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+  context: ActorContext[SudokuProgressTracker.Command],
+  sudokuSolver: ActorRef[SudokuProgressTracker.Response]
+) {
 
   import SudokuProgressTracker._
 
-   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
-    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
-      rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
-      collectEndState()
-    case NewUpdatesInFlight(updateCount) =>
-      trackProgress(updatesInFlight + updateCount)
-    case msg: SudokuDetailState =>
-      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-      Behaviors.same
-  }
+  def trackProgress(updatesInFlight: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+        rowDetailProcessors.foreach ((_, processor) =>
+            processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self)
+        )
+        collectEndState()
+      case NewUpdatesInFlight(updateCount) =>
+        trackProgress(updatesInFlight + updateCount)
+      case msg: SudokuDetailState =>
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+        Behaviors.same
+    }
 
-  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+  def collectEndState(remainingRows: Int = 9,
+                      endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]
+  ): Behavior[Command] =
     Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
-        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        sudokuSolver ! Result(
+          (detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map {
+            case SudokuDetailState(_, state) => state
+          }
+        )
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
@@ -53,4 +66,3 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
         Behaviors.same
     }
 }
-

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 
 import scala.concurrent.duration._
 
@@ -27,61 +27,72 @@ object SudokuSolver {
   
   import SudokuDetailProcessor.UpdateSender
 
-  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[CommandAndResponses]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+  def genDetailProcessors[A <: SudokoDetailType: UpdateSender](
+    context: ActorContext[CommandAndResponses]
+  ): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
     import scala.language.implicitConversions
-    cellIndexesVector.map {
-      index =>
+    cellIndexesVector
+      .map { index =>
         val detailProcessorName = summon[UpdateSender[A]].processorName(index)
         val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
         (index, detailProcessor)
-    }.to(Map) // In Scala 2.13 this can be .to(Map)
+      }
+      .to(Map)
   }
 
   def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
-    Behaviors.supervise[CommandAndResponses] {
-      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
-        Behaviors.setup { context =>
-          new SudokuSolver(context, buffer).idle()
+    Behaviors
+      .supervise[CommandAndResponses] {
+        Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) {
+          buffer =>
+            Behaviors.setup { context =>
+              new SudokuSolver(context, buffer).idle()
+            }
         }
       }
-    }.onFailure[Exception](
-      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
-    ).narrow
+      .onFailure[Exception](
+        SupervisorStrategy
+          .restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+      ).narrow
 }
 
 class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndResponses],
-                            buffer: StashBuffer[SudokuSolver.CommandAndResponses]) {
+                            buffer: StashBuffer[SudokuSolver.CommandAndResponses]
+) {
   import CellMappings._
   import SudokuSolver._
 
-  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val rowDetailProcessors = genDetailProcessors[Row](context)
   private val columnDetailProcessors = genDetailProcessors[Column](context)
-  private val blockDetailProcessors  = genDetailProcessors[Block](context)
-  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+  private val blockDetailProcessors = genDetailProcessors[Block](context)
+  private val allDetailProcessors =
+    List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
 
   private val progressTracker =
-    context.spawn(SudokuProgressTracker(rowDetailProcessors, context.self), "sudoku-progress-tracker")
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, context.self),
+                  "sudoku-progress-tracker"
+    )
 
-  def idle(): Behavior[CommandAndResponses] = Behaviors.receiveMessage {
+  def idle(): Behavior[CommandAndResponses] =
+    Behaviors.receiveMessage {
 
-    case InitialRowUpdates(rowUpdates, sender) =>
-      rowUpdates.foreach {
-        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
-          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, context.self)
-      }
-      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
-      processRequest(Some(sender), System.currentTimeMillis())
-    case unexpectedMsg =>
-      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-      Behaviors.same
+      case InitialRowUpdates(rowUpdates, sender) =>
+        rowUpdates.foreach {
+          case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+            rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, context.self)
+        }
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+        processRequest(Some(sender), System.currentTimeMillis())
+      case unexpectedMsg =>
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
+        Behaviors.same
 
-  }
+    }
 
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[CommandAndResponses] = Behaviors.receiveMessage {
-    case response: SudokuDetailProcessor.Response => response match {
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[CommandAndResponses] =
+    Behaviors.receiveMessage {
       case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
         updates.foreach { (rowCellNr, newCellContent) =>
-
           val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
           val columnUpdate = Vector(columnCellNr -> newCellContent)
           columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, context.self)
@@ -94,7 +105,6 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         Behaviors.same
       case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
         updates.foreach { (colCellNr, newCellContent) =>
-
           val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
           val rowUpdate = Vector(rowCellNr -> newCellContent)
           rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, context.self)
@@ -107,7 +117,6 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         Behaviors.same
       case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
         updates.foreach { (blockCellNr, newCellContent) =>
-
           val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
           val rowUpdate = Vector(rowCellNr -> newCellContent)
           rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, context.self)
@@ -118,29 +127,29 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         }
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
         Behaviors.same
-      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
+      case unchanged @ SudokuDetailProcessor.SudokuDetailUnchanged =>
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
         Behaviors.same
-    }
-    case result: SudokuProgressTracker.Response => result match {
+
       case SudokuProgressTracker.Result(sudoku) =>
-        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
+        context.log.info(
+          s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds"
+        )
         requestor.get ! SudokuSolution(sudoku)
         resetAllDetailProcessors()
         buffer.unstashAll(idle())
-    }
-    case msg: InitialRowUpdates if buffer.isFull =>
-      context.log.info(s"DROPPING REQUEST")
-      Behaviors.same
-    case msg: InitialRowUpdates =>
-      buffer.stash(msg)
-      Behaviors.same
-  }
 
-  private def resetAllDetailProcessors(): Unit = {
+      case msg: InitialRowUpdates if buffer.isFull =>
+        context.log.info(s"DROPPING REQUEST")
+        Behaviors.same
+      case msg: InitialRowUpdates =>
+        buffer.stash(msg)
+        Behaviors.same
+    }
+
+  private def resetAllDetailProcessors(): Unit =
     for {
       processors <- allDetailProcessors
       (_, processor) <- processors
     } processor ! SudokuDetailProcessor.ResetSudokuDetailState
-  }
 }

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS => Millis }
 
 object SudokuSolverSettings {
 

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -22,25 +22,28 @@ package org.lunatechlabs.dotty
 
 import akka.NotUsed
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
-import akka.actor.typed.scaladsl.{Behaviors, Routers}
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
-import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import akka.actor.typed.{ ActorSystem, Behavior, Terminated }
+import org.lunatechlabs.dotty.sudoku.{ SudokuProblemSender, SudokuSolver, SudokuSolverSettings }
 import scala.io.StdIn
-import Console.{GREEN, RESET}
+import scala.Console.{ GREEN, RESET }
 
 object Main {
-  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
-    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
-    // Start a SodukuSolver
-    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
-    // Start a Sudoku problem sender
-    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+  def apply(): Behavior[NotUsed] =
+    Behaviors.setup { context =>
+      val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+      // Start a SodukuSolver
+      val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+      // Start a Sudoku problem sender
+      context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings),
+                    "sudoku-problem-sender"
+      )
 
-    Behaviors.receiveSignal {
-      case (_, Terminated(_)) =>
-        Behaviors.stopped
+      Behaviors.receiveSignal {
+        case (_, Terminated(_)) =>
+          Behaviors.stopped
+      }
     }
-  }
 }
 
 object SudokuSolverMain {

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -15,8 +15,8 @@ object CellMappings {
     rowToBlockCoordinates(cellNr, columnNr)
 
   def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+    ((blockNr / 3) * 3 + cellNr / 3, (blockNr % 3) * 3 + cellNr % 3)
 
   def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+    ((blockNr % 3) * 3 + cellNr % 3, (blockNr / 3) * 3 + cellNr / 3)
 }

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -4,14 +4,14 @@ package org.lunatechlabs.dotty.sudoku
 extension reductionRules on (reductionSet: ReductionSet) {
 
   def applyReductionRuleOne: ReductionSet = {
-    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
+    val inputCellsGrouped = reductionSet.filter {_.size <= 7}.groupBy(identity)
     val completeInputCellGroups = inputCellsGrouped filter { (set, setOccurrences) =>
       set.size == setOccurrences.length
     }
     val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
     completeAndIsolatedValueSets.foldLeft(reductionSet) { (cells, caivSet) =>
-      cells.map {
-        cell => if (cell != caivSet) cell &~ caivSet else cell
+      cells.map { cell =>
+        if (cell != caivSet) cell &~ caivSet else cell
       }
     }
   }
@@ -25,16 +25,17 @@ extension reductionRules on (reductionSet: ReductionSet) {
     }
 
     val cellIndexesToValues =
-      CELLPossibleValues.zip(valueOccurrences)
-        .groupBy ((value, occurrence) => occurrence)
-        .filter  ((loc, occ) => loc.length == occ.length && loc.length <= 6 )
+      CELLPossibleValues
+        .zip(valueOccurrences)
+        .groupBy ((value, occurrence) => occurrence )
+        .filter { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
 
     val cellIndexListToReducedValue = cellIndexesToValues.map { (index, seq) =>
       (index, (seq.map ((value, _) => value )).toSet)
     }
 
-    val cellIndexToReducedValue = cellIndexListToReducedValue flatMap { (cellIndexList, reducedValue) => 
-      cellIndexList map { cellIndex => cellIndex -> reducedValue }
+    val cellIndexToReducedValue = cellIndexListToReducedValue.flatMap { (cellIndexList, reducedValue) =>
+      cellIndexList.map(cellIndex => cellIndex -> reducedValue)
     }
 
     reductionSet.zipWithIndex.foldRight(Vector.empty[CellContent]) {

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -35,7 +35,6 @@ object SudokuDetailProcessor {
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit
-
     def processorName(id: Int): String
   }
 
@@ -43,19 +42,19 @@ object SudokuDetailProcessor {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit = {
       sender ! RowUpdate(id, cellUpdates)
     }
-    override def processorName(id: Int): String = s"row-processor-$id"
+    def processorName(id: Int): String = s"row-processor-$id"
   }
 
   given UpdateSender[Column] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"col-processor-$id"
+    def processorName(id: Int): String = s"col-processor-$id"
   }
 
   given UpdateSender[Block] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
       sender ! BlockUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"blk-processor-$id"
+    def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -2,8 +2,8 @@ package org.lunatechlabs.dotty.sudoku
 
 import java.io.File
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProblemSender {
 
@@ -15,8 +15,9 @@ object SudokuProblemSender {
   type CommandAndResponses = Command | SudokuSolver.Response
 
   private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
-    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
-      .map((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
+    SudokuIO
+      .readSudokuFromFile(new File("sudokus/001.sudoku"))
+      .map ((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
 
   def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
             sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
@@ -35,45 +36,51 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
 
   private val initialSudokuField = rowUpdates.toSudokuField
 
-  private val rowUpdatesSeq = LazyList.continually(
-    Vector(
-      initialSudokuField,
-      initialSudokuField.flipVertically,
-      initialSudokuField.flipHorizontally,
-      initialSudokuField.flipHorizontally.flipVertically,
-      initialSudokuField.flipVertically.flipHorizontally,
-      initialSudokuField.columnSwap(0,1),
-      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW,
-      initialSudokuField.rotateCCW,
-      initialSudokuField.rotateCW.rotateCW,
-      initialSudokuField.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.flipVertically.transpose,
-      initialSudokuField.flipVertically.rotateCW,
-      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
-      initialSudokuField.rotateCW.rotateCW.transpose
-    ).map(_.toRowUpdates)).flatten.iterator
+  private val rowUpdatesSeq = LazyList
+    .continually(
+      Vector(
+        initialSudokuField,
+        initialSudokuField.flipVertically,
+        initialSudokuField.flipHorizontally,
+        initialSudokuField.flipHorizontally.flipVertically,
+        initialSudokuField.flipVertically.flipHorizontally,
+        initialSudokuField.columnSwap(0, 1),
+        initialSudokuField.rowSwap(4, 5).rowSwap(0, 2),
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW,
+        initialSudokuField.rotateCCW,
+        initialSudokuField.rotateCW.rotateCW,
+        initialSudokuField.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.flipVertically.transpose,
+        initialSudokuField.flipVertically.rotateCW,
+        initialSudokuField.columnSwap(4, 5).columnSwap(0, 2).rowSwap(3, 4),
+        initialSudokuField.rotateCW.rotateCW.transpose
+      ).map(_.toRowUpdates)
+    )
+    .flatten
+    .iterator
 
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
-  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+  timers.startTimerAtFixedRate(SendNewSudoku,
+                               problemSendInterval
+  ) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[CommandAndResponses] = Behaviors.receiveMessage {
-    case SendNewSudoku =>
-      context.log.debug("sending new sudoku problem")
-      val nextRowUpdates = rowUpdatesSeq.next
-      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, context.self)
-      Behaviors.same
-    case solution: SudokuSolver.SudokuSolution =>
-      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
-      Behaviors.same
-  }
+  def sending(): Behavior[CommandAndResponses] = 
+    Behaviors.receiveMessage {
+      case SendNewSudoku =>
+        context.log.debug("sending new sudoku problem")
+        val nextRowUpdates = rowUpdatesSeq.next
+        sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, context.self)
+        Behaviors.same
+      case solution: SudokuSolver.SudokuSolution =>
+        context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+        Behaviors.same
+    }
 }
-

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProgressTracker {
 
@@ -18,33 +18,46 @@ object SudokuProgressTracker {
   export Response._
 
   def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+            sudokuSolver: ActorRef[Response]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
-      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver)
+        .trackProgress(updatesInFlight = 0)
     }
 }
 
-class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-                            context: ActorContext[SudokuProgressTracker.Command],
-                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+class SudokuProgressTracker private (
+  rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+  context: ActorContext[SudokuProgressTracker.Command],
+  sudokuSolver: ActorRef[SudokuProgressTracker.Response]
+) {
 
   import SudokuProgressTracker._
 
-   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
-    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
-      rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
-      collectEndState()
-    case NewUpdatesInFlight(updateCount) =>
-      trackProgress(updatesInFlight + updateCount)
-    case msg: SudokuDetailState =>
-      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-      Behaviors.same
-  }
+  def trackProgress(updatesInFlight: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+        rowDetailProcessors.foreach ((_, processor) =>
+            processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self)
+        )
+        collectEndState()
+      case NewUpdatesInFlight(updateCount) =>
+        trackProgress(updatesInFlight + updateCount)
+      case msg: SudokuDetailState =>
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+        Behaviors.same
+    }
 
-  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+  def collectEndState(remainingRows: Int = 9,
+                      endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]
+  ): Behavior[Command] =
     Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
-        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        sudokuSolver ! Result(
+          (detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map {
+            case SudokuDetailState(_, state) => state
+          }
+        )
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
@@ -53,4 +66,3 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
         Behaviors.same
     }
 }
-

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 
 import scala.concurrent.duration._
 
@@ -27,61 +27,72 @@ object SudokuSolver {
 
   import SudokuDetailProcessor.UpdateSender
 
-  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[CommandAndResponses]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+  def genDetailProcessors[A <: SudokoDetailType: UpdateSender](
+    context: ActorContext[CommandAndResponses]
+  ): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
     import scala.language.implicitConversions
-    cellIndexesVector.map {
-      index =>
+    cellIndexesVector
+      .map { index =>
         val detailProcessorName = summon[UpdateSender[A]].processorName(index)
         val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
         (index, detailProcessor)
-    }.to(Map) // In Scala 2.13 this can be .to(Map)
+      }
+      .to(Map)
   }
 
   def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
-    Behaviors.supervise[CommandAndResponses] {
-      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
-        Behaviors.setup { context =>
-          new SudokuSolver(context, buffer).idle()
+    Behaviors
+      .supervise[CommandAndResponses] {
+        Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) {
+          buffer =>
+            Behaviors.setup { context =>
+              new SudokuSolver(context, buffer).idle()
+            }
         }
       }
-    }.onFailure[Exception](
-      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
-    ).narrow
+      .onFailure[Exception](
+        SupervisorStrategy
+          .restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+      ).narrow
 }
 
 class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndResponses],
-                            buffer: StashBuffer[SudokuSolver.CommandAndResponses]) {
+                            buffer: StashBuffer[SudokuSolver.CommandAndResponses]
+) {
   import CellMappings._
   import SudokuSolver._
 
-  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val rowDetailProcessors = genDetailProcessors[Row](context)
   private val columnDetailProcessors = genDetailProcessors[Column](context)
-  private val blockDetailProcessors  = genDetailProcessors[Block](context)
-  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+  private val blockDetailProcessors = genDetailProcessors[Block](context)
+  private val allDetailProcessors =
+    List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
 
   private val progressTracker =
-    context.spawn(SudokuProgressTracker(rowDetailProcessors, context.self), "sudoku-progress-tracker")
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, context.self),
+                  "sudoku-progress-tracker"
+    )
 
-  def idle(): Behavior[CommandAndResponses] = Behaviors.receiveMessage {
+  def idle(): Behavior[CommandAndResponses] =
+    Behaviors.receiveMessage {
 
-    case InitialRowUpdates(rowUpdates, sender) =>
-      rowUpdates.foreach {
-        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
-          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, context.self)
-      }
-      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
-      processRequest(Some(sender), System.currentTimeMillis())
-    case unexpectedMsg =>
-      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-      Behaviors.same
+      case InitialRowUpdates(rowUpdates, sender) =>
+        rowUpdates.foreach {
+          case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+            rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, context.self)
+        }
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+        processRequest(Some(sender), System.currentTimeMillis())
+      case unexpectedMsg =>
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
+        Behaviors.same
 
-  }
+    }
 
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[CommandAndResponses] = Behaviors.receiveMessage {
-    case response: SudokuDetailProcessor.Response => response match {
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[CommandAndResponses] =
+    Behaviors.receiveMessage {
       case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
         updates.foreach { (rowCellNr, newCellContent) =>
-
           val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
           val columnUpdate = CellUpdates(columnCellNr -> newCellContent)
           columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, context.self)
@@ -94,7 +105,6 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         Behaviors.same
       case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
         updates.foreach { (colCellNr, newCellContent) =>
-
           val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
           val rowUpdate = CellUpdates(rowCellNr -> newCellContent)
           rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, context.self)
@@ -107,7 +117,6 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         Behaviors.same
       case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
         updates.foreach { (blockCellNr, newCellContent) =>
-
           val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
           val rowUpdate = CellUpdates(rowCellNr -> newCellContent)
           rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, context.self)
@@ -118,29 +127,29 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         }
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
         Behaviors.same
-      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
+      case unchanged @ SudokuDetailProcessor.SudokuDetailUnchanged =>
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
         Behaviors.same
-    }
-    case result: SudokuProgressTracker.Response => result match {
+
       case SudokuProgressTracker.Result(sudoku) =>
-        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
+        context.log.info(
+          s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds"
+        )
         requestor.get ! SudokuSolution(sudoku)
         resetAllDetailProcessors()
         buffer.unstashAll(idle())
-    }
-    case msg: InitialRowUpdates if buffer.isFull =>
-      context.log.info(s"DROPPING REQUEST")
-      Behaviors.same
-    case msg: InitialRowUpdates =>
-      buffer.stash(msg)
-      Behaviors.same
-  }
 
-  private def resetAllDetailProcessors(): Unit = {
+      case msg: InitialRowUpdates if buffer.isFull =>
+        context.log.info(s"DROPPING REQUEST")
+        Behaviors.same
+      case msg: InitialRowUpdates =>
+        buffer.stash(msg)
+        Behaviors.same
+    }
+
+  private def resetAllDetailProcessors(): Unit =
     for {
       processors <- allDetailProcessors
       (_, processor) <- processors
     } processor ! SudokuDetailProcessor.ResetSudokuDetailState
-  }
 }

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS => Millis }
 
 object SudokuSolverSettings {
 

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/SudokuSolverMain.scala
@@ -22,25 +22,28 @@ package org.lunatechlabs.dotty
 
 import akka.NotUsed
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
-import akka.actor.typed.scaladsl.{Behaviors, Routers}
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
-import org.lunatechlabs.dotty.sudoku.{SudokuProblemSender, SudokuSolver, SudokuSolverSettings}
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import akka.actor.typed.{ ActorSystem, Behavior, Terminated }
+import org.lunatechlabs.dotty.sudoku.{ SudokuProblemSender, SudokuSolver, SudokuSolverSettings }
 import scala.io.StdIn
-import Console.{GREEN, RESET}
+import scala.Console.{ GREEN, RESET }
 
 object Main {
-  def apply(): Behavior[NotUsed] = Behaviors.setup { context =>
-    val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
-    // Start a SodukuSolver
-    val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
-    // Start a Sudoku problem sender
-    context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings), "sudoku-problem-sender")
+  def apply(): Behavior[NotUsed] =
+    Behaviors.setup { context =>
+      val sudokuSolverSettings = SudokuSolverSettings("sudokusolver.conf")
+      // Start a SodukuSolver
+      val sudokuSolver = context.spawn(SudokuSolver(sudokuSolverSettings), s"sudoku-solver")
+      // Start a Sudoku problem sender
+      context.spawn(SudokuProblemSender(sudokuSolver, sudokuSolverSettings),
+                    "sudoku-problem-sender"
+      )
 
-    Behaviors.receiveSignal {
-      case (_, Terminated(_)) =>
-        Behaviors.stopped
+      Behaviors.receiveSignal {
+        case (_, Terminated(_)) =>
+          Behaviors.stopped
+      }
     }
-  }
 }
 
 object SudokuSolverMain {

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/CellMappings.scala
@@ -15,8 +15,8 @@ object CellMappings {
     rowToBlockCoordinates(cellNr, columnNr)
 
   def blockToRowCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr / 3) * 3 + cellNr / 3 , (blockNr % 3) * 3 + cellNr % 3)
+    ((blockNr / 3) * 3 + cellNr / 3, (blockNr % 3) * 3 + cellNr % 3)
 
   def blockToColumnCoordinates(blockNr: Int, cellNr: Int): (Int, Int) =
-    ((blockNr % 3) * 3 + cellNr % 3 , (blockNr / 3) * 3 + cellNr / 3)
+    ((blockNr % 3) * 3 + cellNr % 3, (blockNr / 3) * 3 + cellNr / 3)
 }

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/ReductionRules.scala
@@ -4,14 +4,14 @@ package org.lunatechlabs.dotty.sudoku
 extension reductionRules on (reductionSet: ReductionSet) {
 
   def applyReductionRuleOne: ReductionSet = {
-    val inputCellsGrouped = reductionSet filter {_.size <= 7} groupBy identity
+    val inputCellsGrouped = reductionSet.filter {_.size <= 7}.groupBy(identity)
     val completeInputCellGroups = inputCellsGrouped filter { (set, setOccurrences) =>
       set.size == setOccurrences.length
     }
     val completeAndIsolatedValueSets = completeInputCellGroups.keys.toList
     completeAndIsolatedValueSets.foldLeft(reductionSet) { (cells, caivSet) =>
-      cells.map {
-        cell => if (cell != caivSet) cell &~ caivSet else cell
+      cells.map { cell =>
+        if (cell != caivSet) cell &~ caivSet else cell
       }
     }
   }
@@ -25,16 +25,17 @@ extension reductionRules on (reductionSet: ReductionSet) {
     }
 
     val cellIndexesToValues =
-      CELLPossibleValues.zip(valueOccurrences)
-        .groupBy ((value, occurrence) => occurrence)
-        .filter  ((loc, occ) => loc.length == occ.length && loc.length <= 6 )
+      CELLPossibleValues
+        .zip(valueOccurrences)
+        .groupBy ((value, occurrence) => occurrence )
+        .filter { case (loc, occ) => loc.length == occ.length && loc.length <= 6 }
 
     val cellIndexListToReducedValue = cellIndexesToValues.map { (index, seq) =>
       (index, (seq.map ((value, _) => value )).toSet)
     }
 
-    val cellIndexToReducedValue = cellIndexListToReducedValue flatMap { (cellIndexList, reducedValue) => 
-      cellIndexList map { cellIndex => cellIndex -> reducedValue }
+    val cellIndexToReducedValue = cellIndexListToReducedValue.flatMap { (cellIndexList, reducedValue) =>
+      cellIndexList.map(cellIndex => cellIndex -> reducedValue)
     }
 
     reductionSet.zipWithIndex.foldRight(Vector.empty[CellContent]) {

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuDetailProcessor.scala
@@ -35,7 +35,6 @@ object SudokuDetailProcessor {
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit
-
     def processorName(id: Int): String
   }
 
@@ -43,19 +42,19 @@ object SudokuDetailProcessor {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit = {
       sender ! RowUpdate(id, cellUpdates)
     }
-    override def processorName(id: Int): String = s"row-processor-$id"
+    def processorName(id: Int): String = s"row-processor-$id"
   }
 
   given UpdateSender[Column] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"col-processor-$id"
+    def processorName(id: Int): String = s"col-processor-$id"
   }
 
   given UpdateSender[Block] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(using sender: ActorRef[Response]): Unit =
       sender ! BlockUpdate(id, cellUpdates)
-    override def processorName(id: Int): String = s"blk-processor-$id"
+    def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProblemSender.scala
@@ -2,8 +2,8 @@ package org.lunatechlabs.dotty.sudoku
 
 import java.io.File
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProblemSender {
 
@@ -15,8 +15,9 @@ object SudokuProblemSender {
   type CommandAndResponses = Command | SudokuSolver.Response
 
   private val rowUpdates: Vector[SudokuDetailProcessor.RowUpdate] =
-    SudokuIO.readSudokuFromFile(new File("sudokus/001.sudoku"))
-      .map((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
+    SudokuIO
+      .readSudokuFromFile(new File("sudokus/001.sudoku"))
+      .map ((rowIndex, update) => SudokuDetailProcessor.RowUpdate(rowIndex, update))
 
   def apply(sudokuSolver: ActorRef[SudokuSolver.Command],
             sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
@@ -35,45 +36,51 @@ class SudokuProblemSender private (sudokuSolver: ActorRef[SudokuSolver.Command],
 
   private val initialSudokuField = rowUpdates.toSudokuField
 
-  private val rowUpdatesSeq = LazyList.continually(
-    Vector(
-      initialSudokuField,
-      initialSudokuField.flipVertically,
-      initialSudokuField.flipHorizontally,
-      initialSudokuField.flipHorizontally.flipVertically,
-      initialSudokuField.flipVertically.flipHorizontally,
-      initialSudokuField.columnSwap(0,1),
-      initialSudokuField.rowSwap(4,5).rowSwap(0, 2),
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW,
-      initialSudokuField.rotateCCW,
-      initialSudokuField.rotateCW.rotateCW,
-      initialSudokuField.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.rotateCCW.transpose,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.randomSwapAround,
-      initialSudokuField.flipVertically.transpose,
-      initialSudokuField.flipVertically.rotateCW,
-      initialSudokuField.columnSwap(4,5).columnSwap(0, 2).rowSwap(3,4),
-      initialSudokuField.rotateCW.rotateCW.transpose
-    ).map(_.toRowUpdates)).flatten.iterator
+  private val rowUpdatesSeq = LazyList
+    .continually(
+      Vector(
+        initialSudokuField,
+        initialSudokuField.flipVertically,
+        initialSudokuField.flipHorizontally,
+        initialSudokuField.flipHorizontally.flipVertically,
+        initialSudokuField.flipVertically.flipHorizontally,
+        initialSudokuField.columnSwap(0, 1),
+        initialSudokuField.rowSwap(4, 5).rowSwap(0, 2),
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW,
+        initialSudokuField.rotateCCW,
+        initialSudokuField.rotateCW.rotateCW,
+        initialSudokuField.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.rotateCCW.transpose,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.randomSwapAround,
+        initialSudokuField.flipVertically.transpose,
+        initialSudokuField.flipVertically.rotateCW,
+        initialSudokuField.columnSwap(4, 5).columnSwap(0, 2).rowSwap(3, 4),
+        initialSudokuField.rotateCW.rotateCW.transpose
+      ).map(_.toRowUpdates)
+    )
+    .flatten
+    .iterator
 
   private val problemSendInterval = sudokuSolverSettings.ProblemSender.SendInterval
-  timers.startTimerAtFixedRate(SendNewSudoku, problemSendInterval) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
+  timers.startTimerAtFixedRate(SendNewSudoku,
+                               problemSendInterval
+  ) // on a 5 node RPi 4 based cluster in steady state, this can be lowered to about 6ms
 
-  def sending(): Behavior[CommandAndResponses] = Behaviors.receiveMessage {
-    case SendNewSudoku =>
-      context.log.debug("sending new sudoku problem")
-      val nextRowUpdates = rowUpdatesSeq.next
-      sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, context.self)
-      Behaviors.same
-    case solution: SudokuSolver.SudokuSolution =>
-      context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
-      Behaviors.same
-  }
+  def sending(): Behavior[CommandAndResponses] = 
+    Behaviors.receiveMessage {
+      case SendNewSudoku =>
+        context.log.debug("sending new sudoku problem")
+        val nextRowUpdates = rowUpdatesSeq.next
+        sudokuSolver ! SudokuSolver.InitialRowUpdates(nextRowUpdates, context.self)
+        Behaviors.same
+      case solution: SudokuSolver.SudokuSolution =>
+        context.log.info(s"${SudokuIO.sudokuPrinter(solution)}")
+        Behaviors.same
+    }
 }
-

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -1,7 +1,7 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
 
 object SudokuProgressTracker {
 
@@ -18,33 +18,46 @@ object SudokuProgressTracker {
   export Response._
 
   def apply(rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-            sudokuSolver: ActorRef[Response]): Behavior[Command] =
+            sudokuSolver: ActorRef[Response]
+  ): Behavior[Command] =
     Behaviors.setup { context =>
-      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver).trackProgress(updatesInFlight = 0)
+      new SudokuProgressTracker(rowDetailProcessors, context, sudokuSolver)
+        .trackProgress(updatesInFlight = 0)
     }
 }
 
-class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
-                            context: ActorContext[SudokuProgressTracker.Command],
-                            sudokuSolver: ActorRef[SudokuProgressTracker.Response]) {
+class SudokuProgressTracker private (
+  rowDetailProcessors: Map[Int, ActorRef[SudokuDetailProcessor.Command]],
+  context: ActorContext[SudokuProgressTracker.Command],
+  sudokuSolver: ActorRef[SudokuProgressTracker.Response]
+) {
 
   import SudokuProgressTracker._
 
-   def trackProgress(updatesInFlight: Int): Behavior[Command] = Behaviors.receiveMessage {
-    case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
-      rowDetailProcessors.foreach((_, processor) => processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self))
-      collectEndState()
-    case NewUpdatesInFlight(updateCount) =>
-      trackProgress(updatesInFlight + updateCount)
-    case msg: SudokuDetailState =>
-      context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-      Behaviors.same
-  }
+  def trackProgress(updatesInFlight: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case NewUpdatesInFlight(updateCount) if updatesInFlight - 1 == 0 =>
+        rowDetailProcessors.foreach ((_, processor) =>
+            processor ! SudokuDetailProcessor.GetSudokuDetailState(context.self)
+        )
+        collectEndState()
+      case NewUpdatesInFlight(updateCount) =>
+        trackProgress(updatesInFlight + updateCount)
+      case msg: SudokuDetailState =>
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
+        Behaviors.same
+    }
 
-  def collectEndState(remainingRows: Int = 9, endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]): Behavior[Command] =
+  def collectEndState(remainingRows: Int = 9,
+                      endState: Vector[SudokuDetailState] = Vector.empty[SudokuDetailState]
+  ): Behavior[Command] =
     Behaviors.receiveMessage {
       case detail: SudokuDetailState if remainingRows == 1 =>
-        sudokuSolver ! Result((detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map { case SudokuDetailState(_, state) => state})
+        sudokuSolver ! Result(
+          (detail +: endState).sortBy { case SudokuDetailState(idx, _) => idx }.map {
+            case SudokuDetailState(_, state) => state
+          }
+        )
         trackProgress(updatesInFlight = 0)
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
@@ -53,4 +66,3 @@ class SudokuProgressTracker private (rowDetailProcessors: Map[Int, ActorRef[Sudo
         Behaviors.same
     }
 }
-

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 
 import scala.concurrent.duration._
 
@@ -27,61 +27,72 @@ object SudokuSolver {
 
   import SudokuDetailProcessor.UpdateSender
 
-  def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext[CommandAndResponses]): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
+  def genDetailProcessors[A <: SudokoDetailType: UpdateSender](
+    context: ActorContext[CommandAndResponses]
+  ): Map[Int, ActorRef[SudokuDetailProcessor.Command]] = {
     import scala.language.implicitConversions
-    cellIndexesVector.map {
-      index =>
+    cellIndexesVector
+      .map { index =>
         val detailProcessorName = summon[UpdateSender[A]].processorName(index)
         val detailProcessor = context.spawn(SudokuDetailProcessor(index), detailProcessorName)
         (index, detailProcessor)
-    }.to(Map) // In Scala 2.13 this can be .to(Map)
+      }
+      .to(Map)
   }
 
   def apply(sudokuSolverSettings: SudokuSolverSettings): Behavior[Command] =
-    Behaviors.supervise[CommandAndResponses] {
-      Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) { buffer =>
-        Behaviors.setup { context =>
-          new SudokuSolver(context, buffer).idle()
+    Behaviors
+      .supervise[CommandAndResponses] {
+        Behaviors.withStash(capacity = sudokuSolverSettings.SudokuSolver.StashBufferSize) {
+          buffer =>
+            Behaviors.setup { context =>
+              new SudokuSolver(context, buffer).idle()
+            }
         }
       }
-    }.onFailure[Exception](
-      SupervisorStrategy.restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
-    ).narrow
+      .onFailure[Exception](
+        SupervisorStrategy
+          .restartWithBackoff(minBackoff = 5.seconds, maxBackoff = 1.minute, randomFactor = 0.2)
+      ).narrow
 }
 
 class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndResponses],
-                            buffer: StashBuffer[SudokuSolver.CommandAndResponses]) {
+                            buffer: StashBuffer[SudokuSolver.CommandAndResponses]
+) {
   import CellMappings._
   import SudokuSolver._
 
-  private val rowDetailProcessors    = genDetailProcessors[Row](context)
+  private val rowDetailProcessors = genDetailProcessors[Row](context)
   private val columnDetailProcessors = genDetailProcessors[Column](context)
-  private val blockDetailProcessors  = genDetailProcessors[Block](context)
-  private val allDetailProcessors = List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
+  private val blockDetailProcessors = genDetailProcessors[Block](context)
+  private val allDetailProcessors =
+    List(rowDetailProcessors, columnDetailProcessors, blockDetailProcessors)
 
   private val progressTracker =
-    context.spawn(SudokuProgressTracker(rowDetailProcessors, context.self), "sudoku-progress-tracker")
+    context.spawn(SudokuProgressTracker(rowDetailProcessors, context.self),
+                  "sudoku-progress-tracker"
+    )
 
-  def idle(): Behavior[CommandAndResponses] = Behaviors.receiveMessage {
+  def idle(): Behavior[CommandAndResponses] =
+    Behaviors.receiveMessage {
 
-    case InitialRowUpdates(rowUpdates, sender) =>
-      rowUpdates.foreach {
-        case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
-          rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, context.self)
-      }
-      progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
-      processRequest(Some(sender), System.currentTimeMillis())
-    case unexpectedMsg =>
-      context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-      Behaviors.same
+      case InitialRowUpdates(rowUpdates, sender) =>
+        rowUpdates.foreach {
+          case SudokuDetailProcessor.RowUpdate(row, cellUpdates) =>
+            rowDetailProcessors(row) ! SudokuDetailProcessor.Update(cellUpdates, context.self)
+        }
+        progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
+        processRequest(Some(sender), System.currentTimeMillis())
+      case unexpectedMsg =>
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
+        Behaviors.same
 
-  }
+    }
 
-  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[CommandAndResponses] = Behaviors.receiveMessage {
-    case response: SudokuDetailProcessor.Response => response match {
+  def processRequest(requestor: Option[ActorRef[Response]], startTime: Long): Behavior[CommandAndResponses] =
+    Behaviors.receiveMessage {
       case SudokuDetailProcessor.RowUpdate(rowNr, updates) =>
         updates.foreach { (rowCellNr, newCellContent) =>
-
           val (columnNr, columnCellNr) = rowToColumnCoordinates(rowNr, rowCellNr)
           val columnUpdate = CellUpdates(columnCellNr -> newCellContent)
           columnDetailProcessors(columnNr) ! SudokuDetailProcessor.Update(columnUpdate, context.self)
@@ -94,7 +105,6 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         Behaviors.same
       case SudokuDetailProcessor.ColumnUpdate(columnNr, updates) =>
         updates.foreach { (colCellNr, newCellContent) =>
-
           val (rowNr, rowCellNr) = columnToRowCoordinates(columnNr, colCellNr)
           val rowUpdate = CellUpdates(rowCellNr -> newCellContent)
           rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, context.self)
@@ -107,7 +117,6 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         Behaviors.same
       case SudokuDetailProcessor.BlockUpdate(blockNr, updates) =>
         updates.foreach { (blockCellNr, newCellContent) =>
-
           val (rowNr, rowCellNr) = blockToRowCoordinates(blockNr, blockCellNr)
           val rowUpdate = CellUpdates(rowCellNr -> newCellContent)
           rowDetailProcessors(rowNr) ! SudokuDetailProcessor.Update(rowUpdate, context.self)
@@ -118,29 +127,29 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         }
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(2 * updates.size - 1)
         Behaviors.same
-      case unchanged@SudokuDetailProcessor.SudokuDetailUnchanged =>
+      case unchanged @ SudokuDetailProcessor.SudokuDetailUnchanged =>
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(-1)
         Behaviors.same
-    }
-    case result: SudokuProgressTracker.Response => result match {
+
       case SudokuProgressTracker.Result(sudoku) =>
-        context.log.info(s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds")
+        context.log.info(
+          s"Sudoku processing time: ${System.currentTimeMillis() - startTime} milliseconds"
+        )
         requestor.get ! SudokuSolution(sudoku)
         resetAllDetailProcessors()
         buffer.unstashAll(idle())
-    }
-    case msg: InitialRowUpdates if buffer.isFull =>
-      context.log.info(s"DROPPING REQUEST")
-      Behaviors.same
-    case msg: InitialRowUpdates =>
-      buffer.stash(msg)
-      Behaviors.same
-  }
 
-  private def resetAllDetailProcessors(): Unit = {
+      case msg: InitialRowUpdates if buffer.isFull =>
+        context.log.info(s"DROPPING REQUEST")
+        Behaviors.same
+      case msg: InitialRowUpdates =>
+        buffer.stash(msg)
+        Behaviors.same
+    }
+
+  private def resetAllDetailProcessors(): Unit =
     for {
       processors <- allDetailProcessors
       (_, processor) <- processors
     } processor ! SudokuDetailProcessor.ResetSudokuDetailState
-  }
 }

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolverSettings.scala
@@ -1,8 +1,8 @@
 package org.lunatechlabs.dotty.sudoku
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS => Millis}
+import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS => Millis }
 
 object SudokuSolverSettings {
 

--- a/exercises/project/build.properties
+++ b/exercises/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.3.12

--- a/exercises/project/plugins.sbt
+++ b/exercises/project/plugins.sbt
@@ -1,5 +1,5 @@
 // SBT Dotty plugin
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.0")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")
 
 
 


### PR DESCRIPTION
- Use `scalafmt` to format exercise 0
- Plow through all exercises to deal with formatting
- Remove redundant pattern matching in `SudokuSolver`
- Bump sbt/dotty plugin version