### PR TITLE
Ignore .bsp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ collectedLogs.zip
 .bloop/
 .metals/
 .swp
+.bsp
 **/project/metals.sbt
 
 # sbt specific


### PR DESCRIPTION
- Using Build Server Protocol creates .bsp files. Ignore these