### PR TITLE
Bump Scala 3.0.0-M1/Remove workaround/Correct extensions syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ collectedLogs.zip
 .vscode
 *.code-workspace
 
-# Metals/Bloop specific
+# Metals/Bloop/sbt BSP specific
 .bloop/
 .metals/
 .swp

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -40,8 +40,7 @@ class SudokuProgressTracker private (
       case NewUpdatesInFlight(updateCount) =>
         trackProgress(updatesInFlight + updateCount)
       case msg: SudokuDetailState =>
-        // context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-        context.log.error(s"Received unexpected message in state 'trackProgress': ${msg}")
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
         Behaviors.same
     }
 
@@ -59,8 +58,7 @@ class SudokuProgressTracker private (
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
       case msg: NewUpdatesInFlight =>
-        // context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
-        context.log.error(s"Received unexpected message in state 'collectEndState': ${msg}")
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
         Behaviors.same
     }
 }

--- a/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_000_sudoku_solver_initial_state/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -90,8 +90,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
         processRequest(Some(sender), System.currentTimeMillis())
       case unexpectedMsg =>
-        // context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-        context.log.error(s"Received an unexpected message in 'idle' state: ${unexpectedMsg}")
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
 
     }

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -40,8 +40,7 @@ class SudokuProgressTracker private (
       case NewUpdatesInFlight(updateCount) =>
         trackProgress(updatesInFlight + updateCount)
       case msg: SudokuDetailState =>
-        // context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-        context.log.error(s"Received unexpected message in state 'trackProgress': ${msg}")
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
         Behaviors.same
     }
 
@@ -59,8 +58,7 @@ class SudokuProgressTracker private (
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
       case msg: NewUpdatesInFlight =>
-        // context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
-        context.log.error(s"Received unexpected message in state 'collectEndState': ${msg}")
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
         Behaviors.same
     }
 }

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -90,8 +90,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
         processRequest(Some(sender), System.currentTimeMillis())
       case unexpectedMsg =>
-        // context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-        context.log.error(s"Received an unexpected message in 'idle' state: ${unexpectedMsg}")
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
 
     }

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -40,8 +40,7 @@ class SudokuProgressTracker private (
       case NewUpdatesInFlight(updateCount) =>
         trackProgress(updatesInFlight + updateCount)
       case msg: SudokuDetailState =>
-        // context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-        context.log.error(s"Received unexpected message in state 'trackProgress': ${msg}")
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
         Behaviors.same
     }
 
@@ -59,8 +58,7 @@ class SudokuProgressTracker private (
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
       case msg: NewUpdatesInFlight =>
-        // context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
-        context.log.error(s"Received unexpected message in state 'collectEndState': ${msg}")
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
         Behaviors.same
     }
 }

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -90,8 +90,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
         processRequest(Some(sender), System.currentTimeMillis())
       case unexpectedMsg =>
-        // context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-        context.log.error(s"Received an unexpected message in 'idle' state: ${unexpectedMsg}")
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
 
     }

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -39,8 +39,7 @@ class SudokuProgressTracker private (
       case NewUpdatesInFlight(updateCount) =>
         trackProgress(updatesInFlight + updateCount)
       case msg: SudokuDetailState =>
-        // context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-        context.log.error(s"Received unexpected message in state 'trackProgress': ${msg}")
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
         Behaviors.same
     }
 
@@ -58,7 +57,6 @@ class SudokuProgressTracker private (
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
       case msg: NewUpdatesInFlight =>
-        // context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
-        context.log.error(s"Received unexpected message in state 'collectEndState': ${msg}")
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
         Behaviors.same
     }

--- a/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_003_top_level_definitions/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -88,8 +88,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
         processRequest(Some(sender), System.currentTimeMillis())
       case unexpectedMsg =>
-        // context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-        context.log.error(s"Received an unexpected message in 'idle' state: ${unexpectedMsg}")
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
 
     }

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -38,8 +38,7 @@ class SudokuProgressTracker private (
       case NewUpdatesInFlight(updateCount) =>
         trackProgress(updatesInFlight + updateCount)
       case msg: SudokuDetailState =>
-        // context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-        context.log.error(s"Received unexpected message in state 'trackProgress': ${msg}")
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
         Behaviors.same
     }
 
@@ -57,7 +56,6 @@ class SudokuProgressTracker private (
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
       case msg: NewUpdatesInFlight =>
-        // context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
-        context.log.error(s"Received unexpected message in state 'collectEndState': ${msg}")
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
         Behaviors.same
     }

--- a/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_004_parameter_untupling/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -88,8 +88,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
         processRequest(Some(sender), System.currentTimeMillis())
       case unexpectedMsg =>
-        // context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-        context.log.error(s"Received an unexpected message in 'idle' state: ${unexpectedMsg}")
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
 
     }

--- a/exercises/exercise_005_extension_methods/README.md
+++ b/exercises/exercise_005_extension_methods/README.md
@@ -23,31 +23,19 @@ Now you can use it as follows
 With dotty `extension methods`, we can rewrite the above as
 
 ```scala
-def (i: Int).square: Int = i * i
+extension (i: Int)
+  def square: Int = i * i
 
 4.square
 // val res0: Int = 16
 ```
 
-More than one extension methods can be wrapped inside an `Extension Instance`,
-in order to make them available as methods without needing to be imported explicitly.
+Multiple extension methods on the same type can be defined just as easily. For example:
 
 ```scala
-extension {
-  def (x: Int).square : Int = x * x
-  def (x: Int).isEven: Boolean = x % 2 == 0
-}
-```
-
-When a series of extension methods need to be defined on the same type,
-encoding them one by one quickly becomes tedious. So-called
-`Collective Extensions` can group the definitions together.
-
-```scala
-extension on (x: Int){
-  def square : Int = x * x
-  def isEven: Boolean = x % 2 == 0
-}
+extension (i: Int):
+  def square: Int = i * i
+  def isEven: Boolean = i % 2 == 0
 ```
 
 > At present, Collective extensions have a limitation: the individual extension 

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -38,8 +38,7 @@ class SudokuProgressTracker private (
       case NewUpdatesInFlight(updateCount) =>
         trackProgress(updatesInFlight + updateCount)
       case msg: SudokuDetailState =>
-        // context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-        context.log.error(s"Received unexpected message in state 'trackProgress': ${msg}")
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
         Behaviors.same
     }
 
@@ -57,7 +56,6 @@ class SudokuProgressTracker private (
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
       case msg: NewUpdatesInFlight =>
-        // context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
-        context.log.error(s"Received unexpected message in state 'collectEndState': ${msg}")
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
         Behaviors.same
     }

--- a/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_005_extension_methods/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -88,8 +88,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
         processRequest(Some(sender), System.currentTimeMillis())
       case unexpectedMsg =>
-        // context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-        context.log.error(s"Received an unexpected message in 'idle' state: ${unexpectedMsg}")
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
 
     }

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -38,8 +38,7 @@ class SudokuProgressTracker private (
       case NewUpdatesInFlight(updateCount) =>
         trackProgress(updatesInFlight + updateCount)
       case msg: SudokuDetailState =>
-        // context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-        context.log.error(s"Received unexpected message in state 'trackProgress': ${msg}")
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
         Behaviors.same
     }
 
@@ -57,7 +56,6 @@ class SudokuProgressTracker private (
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
       case msg: NewUpdatesInFlight =>
-        // context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
-        context.log.error(s"Received unexpected message in state 'collectEndState': ${msg}")
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
         Behaviors.same
     }

--- a/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_006_using_and_summon/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -88,8 +88,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
         processRequest(Some(sender), System.currentTimeMillis())
       case unexpectedMsg =>
-        // context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-        context.log.error(s"Received an unexpected message in 'idle' state: ${unexpectedMsg}")
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
 
     }

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -38,8 +38,7 @@ class SudokuProgressTracker private (
       case NewUpdatesInFlight(updateCount) =>
         trackProgress(updatesInFlight + updateCount)
       case msg: SudokuDetailState =>
-        // context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-        context.log.error(s"Received unexpected message in state 'trackProgress': ${msg}")
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
         Behaviors.same
     }
 
@@ -57,7 +56,6 @@ class SudokuProgressTracker private (
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
       case msg: NewUpdatesInFlight =>
-        // context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
-        context.log.error(s"Received unexpected message in state 'collectEndState': ${msg}")
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
         Behaviors.same
     }

--- a/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_007_givens/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -88,8 +88,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
         processRequest(Some(sender), System.currentTimeMillis())
       case unexpectedMsg =>
-        // context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-        context.log.error(s"Received an unexpected message in 'idle' state: ${unexpectedMsg}")
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
 
     }

--- a/exercises/exercise_008_enum_and_export/README.md
+++ b/exercises/exercise_008_enum_and_export/README.md
@@ -26,16 +26,14 @@ In Dotty, we can use enumerations to encode the protocol in a more succinct way.
 The example protocol listed above can be encoded in the following fashion:
 
 ```scala
-  enum Command {
+  enum Command:
     case CommandA(n: Int)
     case CommandB
     case CommandC(n1: Double)
-  }
 
-  enum Response {
+  enum Response:
     case ResponseA(sum: Double)
     case ResponseB
-  }
 ```
 
 The compiler will desugar this encoding in `case class`es and `case object`s that

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -41,8 +41,7 @@ class SudokuProgressTracker private (
       case NewUpdatesInFlight(updateCount) =>
         trackProgress(updatesInFlight + updateCount)
       case msg: SudokuDetailState =>
-        // context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-        context.log.error(s"Received unexpected message in state 'trackProgress': ${msg}")
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
         Behaviors.same
     }
 
@@ -60,7 +59,6 @@ class SudokuProgressTracker private (
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
       case msg: NewUpdatesInFlight =>
-        // context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
-        context.log.error(s"Received unexpected message in state 'collectEndState': ${msg}")
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
         Behaviors.same
     }

--- a/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_008_enum_and_export/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -86,8 +86,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.Command],
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
         processRequest(Some(sender), System.currentTimeMillis())
       case unexpectedMsg =>
-        // context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-        context.log.error(s"Received an unexpected message in 'idle' state: ${unexpectedMsg}")
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
 
     }

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -41,8 +41,7 @@ class SudokuProgressTracker private (
       case NewUpdatesInFlight(updateCount) =>
         trackProgress(updatesInFlight + updateCount)
       case msg: SudokuDetailState =>
-        // context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-        context.log.error(s"Received unexpected message in state 'trackProgress': ${msg}")
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
         Behaviors.same
     }
 
@@ -60,7 +59,6 @@ class SudokuProgressTracker private (
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
       case msg: NewUpdatesInFlight =>
-        // context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
-        context.log.error(s"Received unexpected message in state 'collectEndState': ${msg}")
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
         Behaviors.same
     }

--- a/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_009_union_types/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -80,8 +80,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
         processRequest(Some(sender), System.currentTimeMillis())
       case unexpectedMsg =>
-        // context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-        context.log.error(s"Received an unexpected message in 'idle' state: ${unexpectedMsg}")
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
 
     }

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -41,8 +41,7 @@ class SudokuProgressTracker private (
       case NewUpdatesInFlight(updateCount) =>
         trackProgress(updatesInFlight + updateCount)
       case msg: SudokuDetailState =>
-        // context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-        context.log.error(s"Received unexpected message in state 'trackProgress': ${msg}")
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
         Behaviors.same
     }
 
@@ -60,7 +59,6 @@ class SudokuProgressTracker private (
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
       case msg: NewUpdatesInFlight =>
-        // context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
-        context.log.error(s"Received unexpected message in state 'collectEndState': ${msg}")
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
         Behaviors.same
     }

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -80,8 +80,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
         processRequest(Some(sender), System.currentTimeMillis())
       case unexpectedMsg =>
-        // context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-        context.log.error(s"Received an unexpected message in 'idle' state: ${unexpectedMsg}")
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
 
     }

--- a/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/TopLevelDefinitions.scala
+++ b/exercises/exercise_010_opaque_type_aliases/src/main/scala/org/lunatechlabs/dotty/sudoku/TopLevelDefinitions.scala
@@ -30,7 +30,8 @@ extension[A] (updates: CellUpdates)
 
   def size: Int = updates.size
 
-def (update: (Int, Set[Int])) +: (updates: CellUpdates): CellUpdates = update +: updates
+extension (update: (Int, Set[Int]))
+  def +: (updates: CellUpdates): CellUpdates = update +: updates
 
 import SudokuDetailProcessor.RowUpdate
 

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuProgressTracker.scala
@@ -41,8 +41,7 @@ class SudokuProgressTracker private (
       case NewUpdatesInFlight(updateCount) =>
         trackProgress(updatesInFlight + updateCount)
       case msg: SudokuDetailState =>
-        // context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
-        context.log.error(s"Received unexpected message in state 'trackProgress': ${msg}")
+        context.log.error("Received unexpected message in state 'trackProgress': {}", msg)
         Behaviors.same
     }
 
@@ -60,7 +59,6 @@ class SudokuProgressTracker private (
       case detail: SudokuDetailState =>
         collectEndState(remainingRows = remainingRows - 1, detail +: endState)
       case msg: NewUpdatesInFlight =>
-        // context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
-        context.log.error(s"Received unexpected message in state 'collectEndState': ${msg}")
+        context.log.error("Received unexpected message in state 'collectEndState': {}", msg)
         Behaviors.same
     }

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/SudokuSolver.scala
@@ -80,8 +80,7 @@ class SudokuSolver private (context: ActorContext[SudokuSolver.CommandAndRespons
         progressTracker ! SudokuProgressTracker.NewUpdatesInFlight(rowUpdates.size)
         processRequest(Some(sender), System.currentTimeMillis())
       case unexpectedMsg =>
-        // context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
-        context.log.error(s"Received an unexpected message in 'idle' state: ${unexpectedMsg}")
+        context.log.error("Received an unexpected message in 'idle' state: {}", unexpectedMsg)
         Behaviors.same
 
     }

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/TopLevelDefinitions.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/TopLevelDefinitions.scala
@@ -32,7 +32,8 @@ extension[A] (updates: CellUpdates)
 
   def size: Int = updates.size
 
-def (update: (Int, Set[Int])) +: (updates: CellUpdates): CellUpdates = update +: updates
+extension (update: (Int, Set[Int]))
+  def +: (updates: CellUpdates): CellUpdates = update +: updates
 
 import SudokuDetailProcessor.RowUpdate
 

--- a/exercises/project/Dependencies.scala
+++ b/exercises/project/Dependencies.scala
@@ -21,10 +21,10 @@
 import sbt._
 
 object Version {
-  val akkaVer           = "2.6.8"
+  val akkaVer           = "2.6.10"
   val logbackVer        = "1.2.3"
-  val mUnitVer          = "0.7.12"
-  val scalaVersion      = "0.27.0-RC1"
+  val mUnitVer          = "0.7.16"
+  val scalaVersion      = "3.0.0-M1"
 }
 
 object Dependencies {

--- a/exercises/project/build.properties
+++ b/exercises/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.1

--- a/exercises/project/plugins.sbt
+++ b/exercises/project/plugins.sbt
@@ -1,5 +1,5 @@
 // SBT Dotty plugin
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.5")
 
 
 


### PR DESCRIPTION
- Dotty 0.27.0-RC1 broke logging calls due to [Ambiguous overload between varargs and non-varargs #9688](https://github.com/lampepfl/dotty/issues/9688)
  which was fixed in [Fix vararg overloading #9732](https://github.com/lampepfl/dotty/pull/9732)
- Remove a few remaining extension methods that still used an 'older' extension
  mothod syntax