### PR TITLE
Bump to Scala 3.0.0-M2, munit, sbt-dotty plugin and sbt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           out-file-path: "."
       - run: |
           unzip course-management-tools.zip
-          echo "::add-path::$GITHUB_WORKSPACE/course-management-tools/bin"
+          echo "$GITHUB_WORKSPACE/course-management-tools/bin" >> $GITHUB_PATH
       
       - name: Set up JDK 11
         uses: actions/setup-java@v1
@@ -88,7 +88,7 @@ jobs:
           out-file-path: "."
       - run: |
           unzip course-management-tools.zip
-          echo "::add-path::$GITHUB_WORKSPACE/course-management-tools/bin"
+          echo "$GITHUB_WORKSPACE/course-management-tools/bin" >> $GITHUB_PATH
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1

--- a/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/TopLevelDefinitions.scala
+++ b/exercises/exercise_011_multiversal_equality/src/main/scala/org/lunatechlabs/dotty/sudoku/TopLevelDefinitions.scala
@@ -16,7 +16,7 @@ object CellUpdates:
   def apply(updates: (Int, Set[Int])*): CellUpdates = Vector(updates: _*)
 val cellUpdatesEmpty: CellUpdates = Vector.empty[(Int, Set[Int])]
 
-given Eql[CellUpdates, CellUpdates] = Eql.derived
+given CanEqual[CellUpdates, CellUpdates] = CanEqual.derived
 
 extension[A] (updates: CellUpdates)
 

--- a/exercises/project/Dependencies.scala
+++ b/exercises/project/Dependencies.scala
@@ -23,8 +23,8 @@ import sbt._
 object Version {
   val akkaVer           = "2.6.10"
   val logbackVer        = "1.2.3"
-  val mUnitVer          = "0.7.16"
-  val scalaVersion      = "3.0.0-M1"
+  val mUnitVer          = "0.7.19"
+  val scalaVersion      = "3.0.0-M2"
 }
 
 object Dependencies {

--- a/exercises/project/build.properties
+++ b/exercises/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.1
+sbt.version=1.4.4

--- a/exercises/project/plugins.sbt
+++ b/exercises/project/plugins.sbt
@@ -1,5 +1,5 @@
 // SBT Dotty plugin
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.5")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.6")
 
 
 


### PR DESCRIPTION
- Bump to Scala 3.0.0-M2
  - Renaming of `Eql` to `CanEqual` Type Class
- Bump munit, sbt-dotty plugin and sbt itself